### PR TITLE
Handle cache copy failures cleanly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Prevent cache readers from using files protected by `.copying` locks to avoid partial reads.
+- Ensure cache copy failures clean up partial files and surface errors for retry.


### PR DESCRIPTION
## Summary
- ensure cache copy errors clean up partial files and re-raise for retries

## Changes
- wrap cache copy operation in try/except to remove partial targets and log failures
- keep lock cleanup while allowing retries after copy errors

## Docs
- N/A

## Changelog
- CHANGELOG.md

## Test Plan
- python -m compileall custom_nodes/ComfyUI_Arena/autocache/arena_auto_cache.py *(no UI impact)*

## Risks
- Low: touches cache copy error handling only

## Rollback
- Revert this PR

## Checklist
- [x] Tests updated or not required
- [ ] Docs updated or not required
- [x] Changelog updated
- [x] Formatting ok
- [ ] CI green (pending)


------
https://chatgpt.com/codex/tasks/task_b_68cd459994788324b0f53fcbe9ba6d02