### PR TITLE
Add package init to expose custom nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent cache readers from using files protected by `.copying` locks to avoid partial reads.
 - Ensure cache copy failures clean up partial files and surface errors for retry.
 - Serialize cache index updates to prevent data races during concurrent access.
+- Restore package-level exports so ComfyUI can import `comfyui-arena-suite` from `custom_nodes`.

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,17 @@
+"""RU: Адаптер для импорта пакета comfyui-arena-suite в ComfyUI."""
+
+from importlib import import_module as _import_module
+
+_arena_module = _import_module(".custom_nodes.ComfyUI_Arena", __name__)
+
+_export_names = getattr(_arena_module, "__all__", None)
+if _export_names is None:
+    _export_names = [name for name in dir(_arena_module) if not name.startswith("_")]
+
+globals().update({name: getattr(_arena_module, name) for name in _export_names})
+__all__ = tuple(_export_names)
+
+# RU: подчистим временные переменные, чтобы не светились наружу
+for _name in ("_import_module", "_arena_module", "_export_names"):
+    globals().pop(_name, None)
+del _name


### PR DESCRIPTION
## Summary
- ensure the package root re-exports the Arena custom nodes so ComfyUI can import them when the repo is vendored

## Changes
- add a top-level `__init__.py` that dynamically forwards public attributes from `custom_nodes.ComfyUI_Arena`
- document the import fix in the `[Unreleased]` changelog entry

## Docs
- N/A

## Changelog
- Updated `[Unreleased]` → `Fixed`

## Test Plan
- python -m compileall __init__.py → compiles without errors

## Risks
- Minimal: the adapter only executes during module import and mirrors existing exports

## Rollback
- Revert this PR

## Checklist
- [x] Tests
- [ ] Docs
- [x] Changelog
- [x] Formatting
- [ ] CI green


------
https://chatgpt.com/codex/tasks/task_b_68cd4cf55574832480773c0bfd1b1a8e