### PR TITLE
Gracefully handle missing Impact Pack dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Docs
+- Document the Impact Pack dependency and credit ltdrdata in the README install instructions.
 ### Fixed
 - Prevent cache readers from using files protected by `.copying` locks to avoid partial reads.
 - Ensure cache copy failures clean up partial files and surface errors for retry.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,13 @@ Custom nodes for ComfyUI with **Arena** prefix. **Single-package layout**:
 3) **Refresh custom nodes**.
 
 > Manual: clone repo; the `custom_nodes/ComfyUI_Arena` folder is ready to use.
-> 
+>
+> **Legacy dependency:** Arena legacy nodes rely on
+> [ComfyUI-Impact-Pack](https://github.com/ltdrdata/ComfyUI-Impact-Pack).
+> Install the pack (ComfyUI Manager or manual clone) so the
+> `ComfyUI-Impact-Pack/modules` directory is on `PYTHONPATH`. Big thanks to
+> ltdrdata and the Impact Pack contributors for their amazing work.
+
 ## Codex workflow
 
 1. Codex генерирует код (EN identifiers, RU comments).

--- a/custom_nodes/ComfyUI_Arena/legacy/__init__.py
+++ b/custom_nodes/ComfyUI_Arena/legacy/__init__.py
@@ -1,12 +1,89 @@
-# __init__.py for F:\ComfyUI\ComfyUI\custom_nodes\ComfyUI_Arena
+"""Legacy Arena node exports.
 
-from .arena_make_tiles_segs import Arena_MakeTilesSegs
+This module optionally registers legacy nodes that depend on the
+`ComfyUI-Impact-Pack` package. When the dependency is missing we keep ComfyUI
+bootable and emit a warning so users know how to install the missing pack.
+"""
 
-# Register the node in ComfyUI
-NODE_CLASS_MAPPINGS = {
-    "Arena_MakeTilesSegs": Arena_MakeTilesSegs
-}
+from __future__ import annotations
 
-NODE_DISPLAY_NAME_MAPPINGS = {
-    "Arena_MakeTilesSegs": "Arena Make Tiles Segments"
-}
+import importlib
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+from typing import Iterable
+
+LOGGER = logging.getLogger(__name__)
+IMPACT_REPO_URL = "https://github.com/ltdrdata/ComfyUI-Impact-Pack"
+IMPACT_MISSING_MESSAGE = (
+    "Impact Pack dependency missing: install it from "
+    f"{IMPACT_REPO_URL} and ensure the `ComfyUI-Impact-Pack/modules` "
+    "directory is available on PYTHONPATH. Legacy Arena nodes are disabled."
+)
+
+_IMPACT_CHECKED = False
+_IMPACT_AVAILABLE = False
+
+
+def _impact_module_dirs() -> Iterable[Path]:
+    """Yield likely locations for the Impact Pack ``modules`` directory."""
+
+    resolved = Path(__file__).resolve()
+    parents = resolved.parents
+    for depth in (2, 3, 4):
+        if len(parents) > depth:
+            candidate = parents[depth] / "ComfyUI-Impact-Pack" / "modules"
+            yield candidate
+
+
+def ensure_impact() -> bool:
+    """Ensure the Impact Pack can be imported, logging guidance if missing."""
+
+    global _IMPACT_CHECKED, _IMPACT_AVAILABLE
+    if _IMPACT_CHECKED:
+        return _IMPACT_AVAILABLE
+
+    _IMPACT_CHECKED = True
+
+    if importlib.util.find_spec("impact") is not None:
+        _IMPACT_AVAILABLE = True
+        return True
+
+    for modules_dir in _impact_module_dirs():
+        if not modules_dir.is_dir():
+            continue
+        modules_path = str(modules_dir)
+        if modules_path not in sys.path:
+            sys.path.append(modules_path)
+        if importlib.util.find_spec("impact") is not None:
+            _IMPACT_AVAILABLE = True
+            return True
+
+    LOGGER.warning(IMPACT_MISSING_MESSAGE)
+    return False
+
+
+IMPACT_AVAILABLE = ensure_impact()
+
+if IMPACT_AVAILABLE:
+    from .arena_make_tiles_segs import Arena_MakeTilesSegs
+
+    NODE_CLASS_MAPPINGS = {
+        "Arena_MakeTilesSegs": Arena_MakeTilesSegs
+    }
+    NODE_DISPLAY_NAME_MAPPINGS = {
+        "Arena_MakeTilesSegs": "Arena Make Tiles Segments"
+    }
+else:
+    NODE_CLASS_MAPPINGS = {}
+    NODE_DISPLAY_NAME_MAPPINGS = {}
+
+
+__all__ = [
+    "IMPACT_AVAILABLE",
+    "IMPACT_MISSING_MESSAGE",
+    "NODE_CLASS_MAPPINGS",
+    "NODE_DISPLAY_NAME_MAPPINGS",
+    "ensure_impact",
+]

--- a/custom_nodes/ComfyUI_Arena/legacy/arena_make_tiles_segs.py
+++ b/custom_nodes/ComfyUI_Arena/legacy/arena_make_tiles_segs.py
@@ -1,13 +1,21 @@
-import os
-import sys
+import logging
 import math
+
 import numpy as np
 import torch
 
-# Import necessary modules from your project
-from impact.core import SEG  # Import SEG class
-from impact.utils import *  # Import all utility functions
-from . import core  # Import core module for mask operations
+from . import IMPACT_AVAILABLE, IMPACT_MISSING_MESSAGE
+
+LOGGER = logging.getLogger(__name__)
+
+if IMPACT_AVAILABLE:
+    from impact.core import SEG  # type: ignore  # Import SEG class
+    from impact.utils import *  # type: ignore  # Import all utility functions
+    from . import core  # Import core module for mask operations
+else:
+    SEG = None  # type: ignore
+    core = None  # type: ignore
+    LOGGER.warning(IMPACT_MISSING_MESSAGE)
 
 class Arena_MakeTilesSegs:
     @classmethod
@@ -35,6 +43,9 @@ class Arena_MakeTilesSegs:
 
     @staticmethod
     def doit(images, width, height, crop_factor, min_overlap, filter_segs_dilation, mask_irregularity=0, irregular_mask_mode="Reuse fast", filter_in_segs_opt=None, filter_out_segs_opt=None):
+        if not IMPACT_AVAILABLE:
+            raise RuntimeError(IMPACT_MISSING_MESSAGE)
+
         # Ensure that min_overlap is less than half the width and height
         if width <= 2 * min_overlap:
             min_overlap = width / 2

--- a/custom_nodes/ComfyUI_Arena/legacy/core.py
+++ b/custom_nodes/ComfyUI_Arena/legacy/core.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 import os
 import warnings
 
@@ -7,7 +8,6 @@ import torch
 from segment_anything import SamPredictor
 
 from comfy_extras.nodes_custom_sampler import Noise_RandomNoise
-from impact.utils import *
 from collections import namedtuple
 import numpy as np
 from skimage.measure import label
@@ -16,15 +16,27 @@ import nodes
 import comfy_extras.nodes_upscale_model as model_upscale
 from server import PromptServer
 import comfy
-import impact.wildcards as wildcards
 import math
 import cv2
 import time
 from comfy import model_management
-from impact import utils
-from impact import impact_sampling
 from concurrent.futures import ThreadPoolExecutor
 import inspect
+
+from . import IMPACT_AVAILABLE, IMPACT_MISSING_MESSAGE, ensure_impact
+
+LOGGER = logging.getLogger(__name__)
+
+if IMPACT_AVAILABLE or ensure_impact():
+    from impact.utils import *  # type: ignore
+    import impact.wildcards as wildcards  # type: ignore
+    from impact import utils  # type: ignore
+    from impact import impact_sampling  # type: ignore
+else:
+    wildcards = None  # type: ignore
+    utils = None  # type: ignore
+    impact_sampling = None  # type: ignore
+    LOGGER.warning(IMPACT_MISSING_MESSAGE)
 
 
 try:


### PR DESCRIPTION
## Summary
* Gracefully skip registering Arena legacy nodes when the Impact Pack is not installed while logging actionable guidance.
* Guard legacy modules so their imports do not fail when the dependency is missing and raise a friendly runtime error if invoked.
* Document the Impact Pack requirement and credit ltdrdata in the README and changelog.

## Changes
* Added an import helper in `legacy/__init__.py` that locates the Impact Pack `modules` directory, extends `sys.path`, and records whether the dependency is available before registering nodes.
* Wrapped Impact Pack imports in `legacy/arena_make_tiles_segs.py` and `legacy/core.py` behind the helper and added runtime guards that explain how to install the dependency when missing.
* Updated README installation instructions and changelog with the Impact Pack note and acknowledgements.

## Docs
* `README.md`

## Changelog
* Added Docs entry under `[Unreleased]` describing the Impact Pack documentation update.

## Test Plan
* CLI — `python -m compileall custom_nodes/ComfyUI_Arena/legacy`

## Risks
* Low: legacy nodes remain unavailable when Impact Pack is genuinely missing.

## Rollback
* Revert this commit.

## Checklist
* [x] Tests
* [x] Docs
* [x] Changelog
* [x] Formatting
* [ ] CI green

------
https://chatgpt.com/codex/tasks/task_b_68cd503fbb18832480b3087ca107b9cc