### PR TITLE
Fix cache stale file handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Docs
 - Document the Impact Pack dependency and credit ltdrdata in the README install instructions.
 ### Fixed
+- Recreate cache entries when stale files with mismatched sizes are detected during reuse.
 - Prevent cache readers from using files protected by `.copying` locks to avoid partial reads.
 - Ensure cache copy failures clean up partial files and surface errors for retry.
 - Serialize cache index updates to prevent data races during concurrent access.


### PR DESCRIPTION
## Summary
- ensure cache recopy triggers when an existing entry's size no longer matches the source

## Changes
- compare cached file size to the source before reusing it and purge stale entries when needed
- log stale cache removal while preserving existing verbose messages
- document the fix in the unreleased changelog section

## Docs
- n/a

## Changelog
- CHANGELOG.md

## Test Plan
- run `python -m compileall custom_nodes/ComfyUI_Arena/autocache/arena_auto_cache.py`

## Risks
- Low: cache files are removed and recopied only when a size mismatch is detected.

## Rollback
- Revert this PR.

## Checklist
- [x] Tests
- [ ] Docs
- [x] Changelog
- [x] Formatting
- [ ] CI green


------
https://chatgpt.com/codex/tasks/task_b_68cd5986bfa083248a758d410f6f2b1d