### PR TITLE
Handle disabled arena autocache gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Docs
 - Document the Impact Pack dependency and credit ltdrdata in the README install instructions.
+- Note that autocache nodes return disabled stubs when `ARENA_CACHE_ENABLE=0`.
 ### Fixed
 - Allow cache lookups to fall back to source files when `.copying` locks persist and clean up stale locks before retrying copies.
 - Retry cache population after clearing stale `.copying` locks so the cache path is reused on the next request.
@@ -16,3 +17,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure cache copy failures clean up partial files and surface errors for retry.
 - Serialize cache index updates to prevent data races during concurrent access.
 - Restore package-level exports so ComfyUI can import `comfyui-arena-suite` from `custom_nodes`.
+- Keep cache helpers importable and return stub responses when the cache is disabled.

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -6,3 +6,7 @@
 - *updater* helper to version and point `current` symlinks/junctions.
 
 WIP parts are scaffolds; implementation to be generated via Codex prompts.
+
+When `ARENA_CACHE_ENABLE=0` the autocache patch stays inactive, while the
+`ArenaAutoCacheStats` and `ArenaAutoCacheTrim` nodes still load and return
+stubbed responses to signal that the cache is disabled.


### PR DESCRIPTION
## Summary
- ensure autocache helper routines are defined regardless of the ARENA_CACHE_ENABLE flag
- short-circuit ArenaAutoCache nodes when caching is disabled and return explanatory stubs

## Changes
- lift LRU/index helper definitions to module scope and reuse them inside the folder_paths patch
- guard ArenaAutoCacheStats and ArenaAutoCacheTrim with disabled-mode responses and keep cache writes safe
- document the disabled-cache behaviour in HOW_IT_WORKS and extend the changelog

## Docs
- docs/HOW_IT_WORKS.md

## Changelog
- entry added under `[Unreleased]`

## Test Plan
- ARENA_CACHE_ENABLE=0 python - <<'PY' ... verify nodes import and return disabled stubs

## Risks
- minimal: shared helpers now import even when cache is disabled, but behaviour remains guarded by the flag

## Rollback
- revert this commit

## Checklist
- [x] Tests
- [x] Docs
- [x] Changelog
- [x] Formatting
- [ ] CI green


------
https://chatgpt.com/codex/tasks/task_b_68cd6ca774f0832498bea6c47f3e3e2f