### PR TITLE
Enhance Arena AutoCache stats and metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Extend Arena AutoCache index metadata to expose byte totals and the last HIT/MISS/TRIM/COPY event.
 ### Docs
 - Document the Impact Pack dependency and credit ltdrdata in the README install instructions.
 - Note that autocache nodes return disabled stubs when `ARENA_CACHE_ENABLE=0`.
+- Describe the expanded AutoCache stats and trim JSON payloads in `custom_nodes/ComfyUI_Arena/README.md`.
 ### Fixed
 - Allow cache lookups to fall back to source files when `.copying` locks persist and clean up stale locks before retrying copies.
 - Retry cache population after clearing stale `.copying` locks so the cache path is reused on the next request.

--- a/custom_nodes/ComfyUI_Arena/README.md
+++ b/custom_nodes/ComfyUI_Arena/README.md
@@ -7,3 +7,27 @@ Single-package for all **Arena** nodes.
 - `updater/` — model updater (WIP).
 
 > Python bytecode and `__pycache__` are excluded by `.gitignore`.
+
+## AutoCache nodes
+
+### ArenaAutoCacheStats
+
+Returns a JSON string with extended cache metadata:
+
+- `category` — ComfyUI asset group.
+- `cache_root` — absolute directory for the cache category.
+- `enabled` — `true` when `ARENA_CACHE_ENABLE=1`.
+- `items` — number of cached files tracked in the index.
+- `total_bytes` / `total_gb` — aggregate cache size (bytes and GiB).
+- `max_size_gb` — configured capacity limit.
+- `last_op` / `last_path` — last cache event (`HIT`, `MISS`, `TRIM`, `COPY`) and the affected path.
+
+### ArenaAutoCacheTrim
+
+Returns a JSON string with the trim result:
+
+- `ok` — `true` if the trim succeeded.
+- `category` — cache category handled by the node.
+- `trimmed` — list of file paths evicted during the run (empty when nothing was removed).
+- `items`, `total_bytes`, `total_gb`, `max_size_gb` — snapshot of the cache after trimming.
+- `note` — human-readable status (`trimmed to limit`, `cache disabled`, etc.).


### PR DESCRIPTION
## Summary
- extend the Arena AutoCache index so it tracks byte totals and the most recent HIT/MISS/TRIM/COPY event
- expose the richer metadata through the Stats node and return detailed results from the Trim node
- document the updated JSON payloads for both nodes

## Changes
- add default index helpers and record last-operation metadata for cache hits, misses, copies and trims
- expand ArenaAutoCacheStats and ArenaAutoCacheTrim outputs to report byte totals, enablement and last-operation info
- refresh the AutoCache README section and note the behaviour change in the changelog

## Docs
- custom_nodes/ComfyUI_Arena/README.md

## Changelog
- Added entry under `[Unreleased]` → `### Changed`
- Added entry under `[Unreleased]` → `### Docs`

## Test Plan
- pytest --ignore=__init__.py *(fails: repository package wrapper cannot import custom_nodes when loaded as `__init__`)*

## Risks
- Minor: cache index metadata persists in JSON and must remain backward compatible

## Rollback
- Revert this commit

## Checklist
- [ ] Tests
- [x] Docs
- [x] Changelog
- [x] Formatting
- [ ] CI green

------
https://chatgpt.com/codex/tasks/task_b_68cd6ea635288324a9aa312f3e353038