### PR TITLE
Aggregate Arena node mappings from submodules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Note that autocache nodes return disabled stubs when `ARENA_CACHE_ENABLE=0`.
 - Describe the expanded AutoCache stats and trim JSON payloads in `custom_nodes/ComfyUI_Arena/README.md`.
 ### Fixed
+- Aggregate Arena node and display mapping exports at the package root so ComfyUI can discover nodes even when optional submodules fail to import.
 - Allow cache lookups to fall back to source files when `.copying` locks persist and clean up stale locks before retrying copies.
 - Retry cache population after clearing stale `.copying` locks so the cache path is reused on the next request.
 - Recreate cache entries when stale files with mismatched sizes are detected during reuse.

--- a/custom_nodes/ComfyUI_Arena/__init__.py
+++ b/custom_nodes/ComfyUI_Arena/__init__.py
@@ -6,15 +6,41 @@
 Идентификаторы — на английском, комментарии — на русском.
 """
 
-from .legacy import __init__ as _legacy_init  # noqa: F401  # RU: импортирует NODE_CLASS_MAPPINGS
+from __future__ import annotations
+
+from types import ModuleType
+
+NODE_CLASS_MAPPINGS: dict[str, type] = {}
+NODE_DISPLAY_NAME_MAPPINGS: dict[str, str] = {}
+
+_SUBMODULES: list[ModuleType] = []
+
+from . import legacy as _legacy  # RU: импортирует обязательные ноды
+
+_SUBMODULES.append(_legacy)
 
 # RU: Попробуем подгрузить WIP-модули, но не упадём, если их нет
 try:  # RU: автокэш (необязателен)
-    from .autocache import __init__ as _autocache_init  # noqa: F401
+    from . import autocache as _autocache
 except Exception as e:  # noqa: BLE001
     print(f"[Arena] autocache disabled: {e}")
+else:
+    _SUBMODULES.append(_autocache)
 
 try:  # RU: обновлятор (необязателен)
-    from .updater import __init__ as _updater_init  # noqa: F401
+    from . import updater as _updater
 except Exception as e:  # noqa: BLE001
     print(f"[Arena] updater disabled: {e}")
+else:
+    _SUBMODULES.append(_updater)
+
+for _module in _SUBMODULES:
+    NODE_CLASS_MAPPINGS.update(getattr(_module, "NODE_CLASS_MAPPINGS", {}))
+    NODE_DISPLAY_NAME_MAPPINGS.update(
+        getattr(_module, "NODE_DISPLAY_NAME_MAPPINGS", {})
+    )
+
+__all__ = [
+    "NODE_CLASS_MAPPINGS",
+    "NODE_DISPLAY_NAME_MAPPINGS",
+]


### PR DESCRIPTION
## Summary
- ensure the Arena package exposes unified node and display mapping dictionaries for ComfyUI

## Changes
- import Arena subpackages safely and collect their NODE_CLASS_MAPPINGS and NODE_DISPLAY_NAME_MAPPINGS
- expose the aggregated dictionaries at the package root via __all__
- document the fix in the Unreleased changelog

## Docs
- N/A

## Changelog
- Updated `[Unreleased]` → `Fixed`

## Test Plan
- python -m compileall custom_nodes/ComfyUI_Arena/__init__.py

## Risks
- Low risk: changes are limited to package exports

## Rollback
- Revert this PR

## Checklist
- [x] Tests
- [ ] Docs
- [x] Changelog
- [x] Formatting
- [ ] CI green


------
https://chatgpt.com/codex/tasks/task_b_68cd75a5a01083248f93e37997286506