### PR TITLE
feat(autocache): runtime config node, StatsEx outputs, live folder_paths patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,36 @@
-# ComfyUI Arena Suite
+﻿# ComfyUI Arena Suite
 
 Custom nodes for ComfyUI with the **Arena** prefix bundled in a **single package**.
 
 ## Features overview
-- **Legacy nodes** — migrated utilities that preserve the existing interfaces while living under `ComfyUI_Arena/legacy`.
-- **AutoCache** — runtime patch for `folder_paths` that prefers an SSD cache to accelerate heavy model loads and exposes stats/trim helpers.
-- **Updater scaffolding** — Hugging Face and CivitAI helpers (WIP) intended to keep local model folders in sync and manage `current` symlinks.
+- **Legacy nodes** вЂ” migrated utilities that preserve the existing interfaces while living under `ComfyUI_Arena/legacy`.
+- **AutoCache** — runtime patch for `folder_paths` that prefers an SSD cache, plus Config/StatsEx/Trim/Manager nodes for in-graph control (see `custom_nodes/ComfyUI_Arena/README.md`).
+- **Updater scaffolding** вЂ” Hugging Face and CivitAI helpers (WIP) intended to keep local model folders in sync and manage `current` symlinks.
 
 ## System requirements
 - **ComfyUI** with custom node support (tested on the current `master` branch).
 - **Python 3.10+** as required by `pyproject.toml`.
 - **Fast SSD storage** when enabling AutoCache to get the best throughput.
-- **[ComfyUI-Impact-Pack](https://github.com/ltdrdata/ComfyUI-Impact-Pack)** for legacy Arena nodes — install it via ComfyUI Manager or manually clone the repository so `ComfyUI-Impact-Pack/modules` is available on `PYTHONPATH`.
+- **[ComfyUI-Impact-Pack](https://github.com/ltdrdata/ComfyUI-Impact-Pack)** for legacy Arena nodes вЂ” install it via ComfyUI Manager or manually clone the repository so `ComfyUI-Impact-Pack/modules` is available on `PYTHONPATH`.
 
 ## Quick usage summary
-1. Install the suite through **ComfyUI Manager → Install from URL** using your repository URL (for example, `https://github.com/<your-org>/comfyui-arena-suite`).
+1. Install the suite through **ComfyUI Manager в†’ Install from URL** using your repository URL (for example, `https://github.com/<your-org>/comfyui-arena-suite`).
 2. Refresh the custom nodes list or restart ComfyUI so the new Arena nodes load.
 3. Drop nodes with the **Arena** prefix into your graph to verify the installation (e.g., `ArenaAutoCacheStats`).
-4. Configure SSD caching and update manifests as needed — see the documentation below for detailed steps.
+4. Configure SSD caching and update manifests as needed вЂ” see the documentation below for detailed steps.
 
 ## Documentation
-- 🇷🇺 Русская документация: [Обзор](docs/ru/index.md), [Быстрый старт](docs/ru/quickstart.md), [CLI](docs/ru/cli.md), [Конфигурация](docs/ru/config.md), [Диагностика](docs/ru/troubleshooting.md).
-- 🇬🇧 English placeholders: [Overview](docs/en/index.md), [Quickstart](docs/en/quickstart.md), [CLI](docs/en/cli.md), [Configuration](docs/en/config.md),
+- рџ‡·рџ‡є Р СѓСЃСЃРєР°СЏ РґРѕРєСѓРјРµРЅС‚Р°С†РёСЏ: [РћР±Р·РѕСЂ](docs/ru/index.md), [Р‘С‹СЃС‚СЂС‹Р№ СЃС‚Р°СЂС‚](docs/ru/quickstart.md), [CLI](docs/ru/cli.md), [РљРѕРЅС„РёРіСѓСЂР°С†РёСЏ](docs/ru/config.md), [Р”РёР°РіРЅРѕСЃС‚РёРєР°](docs/ru/troubleshooting.md).
+- рџ‡¬рџ‡§ English placeholders: [Overview](docs/en/index.md), [Quickstart](docs/en/quickstart.md), [CLI](docs/en/cli.md), [Configuration](docs/en/config.md),
 - [Troubleshooting](docs/en/troubleshooting.md).
 - [Agents rules](AGENTS.md) - guidelines for developing and integrating Codex & ComfyUI agents.
 
 ## Codex workflow
-1. odex генерирует код (EN identifiers, RU comments).
-2. Создаёт/обновляет Issue: `Codex: <module> — <topic> — <date>` с блоками
+1. odex РіРµРЅРµСЂРёСЂСѓРµС‚ РєРѕРґ (EN identifiers, RU comments).
+2. РЎРѕР·РґР°С‘С‚/РѕР±РЅРѕРІР»СЏРµС‚ Issue: `Codex: <module> вЂ” <topic> вЂ” <date>` СЃ Р±Р»РѕРєР°РјРё
    **SUMMARY / ISSUES & TASKS / TEST PLAN / NOTES**.
-3. Все изменения идут через PR; тело PR — по шаблону (см. `.github/pull_request_template.md`).
-4. В коммитах ссылаться на Issue: `Refs #<номер>`.
-5. CHANGELOG (`[Unreleased]`) и docs обновляются в том же PR.
+3. Р’СЃРµ РёР·РјРµРЅРµРЅРёСЏ РёРґСѓС‚ С‡РµСЂРµР· PR; С‚РµР»Рѕ PR вЂ” РїРѕ С€Р°Р±Р»РѕРЅСѓ (СЃРј. `.github/pull_request_template.md`).
+4. Р’ РєРѕРјРјРёС‚Р°С… СЃСЃС‹Р»Р°С‚СЊСЃСЏ РЅР° Issue: `Refs #<РЅРѕРјРµСЂ>`.
+5. CHANGELOG (`[Unreleased]`) Рё docs РѕР±РЅРѕРІР»СЏСЋС‚СЃСЏ РІ С‚РѕРј Р¶Рµ PR.
+
+

--- a/custom_nodes/ComfyUI_Arena/README.md
+++ b/custom_nodes/ComfyUI_Arena/README.md
@@ -1,33 +1,41 @@
-# ComfyUI_Arena
+﻿# ComfyUI_Arena
 
 Single-package for all **Arena** nodes.
 
-- `legacy/` — migrated from local install.
-- `autocache/` — SSD auto-cache (WIP).
-- `updater/` — model updater (WIP).
+- `legacy/` - migrated from local install.
+- `autocache/` - SSD auto-cache.
+- `updater/` - model updater (WIP).
 
 > Python bytecode and `__pycache__` are excluded by `.gitignore`.
 
 ## AutoCache nodes
 
+### ArenaAutoCacheConfig
+
+Runtime configuration helper. Use it near the start of the workflow to pick the cache root, quota and toggle flags.
+
+Inputs (required):
+
+- `cache_root` - path to the SSD cache directory (defaults to current setting).
+- `max_size_gb` - integer capacity limit (GiB).
+- `enable` - switches the LRU cache on/off without restarting ComfyUI.
+- `verbose` - prints debug messages to the console.
+
+Output: single JSON string with `ok`, effective settings and optional `error`/`note` fields.
+
 ### ArenaAutoCacheStats
 
-Returns a JSON string with extended cache metadata:
+Backwards-compatible node that still returns the original JSON summary. Values: `category`, `cache_root`, `enabled`, `items`, `total_bytes`, `total_gb`, `max_size_gb`, `last_op`, `last_path` and optional `note`.
 
-- `category` — ComfyUI asset group.
-- `cache_root` — absolute directory for the cache category.
-- `enabled` — `true` when `ARENA_CACHE_ENABLE=1`.
-- `items` — number of cached files tracked in the index.
-- `total_bytes` / `total_gb` — aggregate cache size (bytes and GiB).
-- `max_size_gb` — configured capacity limit.
-- `last_op` / `last_path` — last cache event (`HIT`, `MISS`, `TRIM`, `COPY`) and the affected path.
+### ArenaAutoCacheStatsEx
+
+Extended statistics with multiple sockets. Outputs: `(json, items, total_gb, cache_root, session_hits, session_misses, session_trims)`. The JSON mirrors the old stats output while the extra sockets expose numeric counters for UI widgets.
 
 ### ArenaAutoCacheTrim
 
-Returns a JSON string with the trim result:
+Triggers manual LRU maintenance for a category. Output JSON includes `ok`, `category`, `trimmed`, `items`, `total_bytes`, `total_gb`, `max_size_gb` and `note`.
 
-- `ok` — `true` if the trim succeeded.
-- `category` — cache category handled by the node.
-- `trimmed` — list of file paths evicted during the run (empty when nothing was removed).
-- `items`, `total_bytes`, `total_gb`, `max_size_gb` — snapshot of the cache after trimming.
-- `note` — human-readable status (`trimmed to limit`, `cache disabled`, etc.).
+### ArenaAutoCacheManager
+
+Convenience combo node. Applies configuration, optionally runs trim (`do_trim = true`) and returns a pair of JSON blobs: latest stats and action log. Useful for dashboard-style graphs; underlying nodes remain available for fine-grained control.
+

--- a/tests/test_arena_auto_cache.py
+++ b/tests/test_arena_auto_cache.py
@@ -1,4 +1,4 @@
-"""Regression tests for Arena AutoCache utilities."""
+﻿"""Regression tests for Arena AutoCache utilities."""
 
 from __future__ import annotations
 
@@ -71,7 +71,7 @@ class ArenaAutoCacheStaleLockTest(unittest.TestCase):
 
             # First request after crash: stale lock should be removed and cache recopied.
             resolved = folder_paths.get_full_path(category, filename)  # type: ignore[attr-defined]
-            self.assertEqual(resolved, str(dst_path))
+            self.assertEqual(Path(resolved).resolve(strict=False), dst_path.resolve(strict=False))
             self.assertFalse(lock_path.exists())
             self.assertEqual(dst_path.read_text(encoding="utf-8"), "fresh-data")
 
@@ -83,7 +83,7 @@ class ArenaAutoCacheStaleLockTest(unittest.TestCase):
 
             # Subsequent requests should keep returning the cache path without recreating locks.
             second_resolved = folder_paths.get_full_path(category, filename)  # type: ignore[attr-defined]
-            self.assertEqual(second_resolved, str(dst_path))
+            self.assertEqual(Path(second_resolved).resolve(strict=False), dst_path.resolve(strict=False))
             self.assertFalse(dst_path.with_suffix(dst_path.suffix + ".copying").exists())
 
 
@@ -160,3 +160,5 @@ class ArenaAutoCacheMissingFileTest(unittest.TestCase):
 
 if __name__ == "__main__":  # pragma: no cover - unittest main hook
     unittest.main()
+
+

--- a/tests/test_autocache_config.py
+++ b/tests/test_autocache_config.py
@@ -1,0 +1,137 @@
+﻿"""Runtime configuration tests for Arena AutoCache."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+MODULE_NAME = "custom_nodes.ComfyUI_Arena.autocache.arena_auto_cache"
+
+
+def _prepare_module(cache_root: Path, source_dir: Path, enable: bool = True):
+    """RU: Собирает заглушку folder_paths и импортирует модуль кеша."""
+
+    folder_paths = types.ModuleType("folder_paths")
+
+    def _get_folder_paths(category: str):
+        return [str(source_dir)] if category == "checkpoints" else []
+
+    def _get_full_path(category: str, name: str):
+        return str(Path(source_dir) / name)
+
+    folder_paths.get_folder_paths = _get_folder_paths  # type: ignore[attr-defined]
+    folder_paths.get_full_path = _get_full_path  # type: ignore[attr-defined]
+    sys.modules["folder_paths"] = folder_paths
+
+    os.environ["ARENA_CACHE_ROOT"] = str(cache_root)
+    os.environ["ARENA_CACHE_ENABLE"] = "1" if enable else "0"
+    os.environ["ARENA_CACHE_VERBOSE"] = "0"
+
+    sys.modules.pop(MODULE_NAME, None)
+    module = importlib.import_module(MODULE_NAME)
+    module._STALE_LOCK_SECONDS = 0.1
+
+    return module, folder_paths
+
+
+def _cleanup_module(testcase: unittest.TestCase) -> None:
+    """RU: Возвращает окружение и импорты в исходное состояние."""
+
+    testcase.addCleanup(sys.modules.pop, MODULE_NAME, None)
+    testcase.addCleanup(sys.modules.pop, "folder_paths", None)
+    testcase.addCleanup(lambda: os.environ.pop("ARENA_CACHE_ROOT", None))
+    testcase.addCleanup(lambda: os.environ.pop("ARENA_CACHE_ENABLE", None))
+    testcase.addCleanup(lambda: os.environ.pop("ARENA_CACHE_VERBOSE", None))
+
+
+class ArenaAutoCacheConfigRuntimeTest(unittest.TestCase):
+    """RU: Проверяет, что рантайм-изменения настроек влияют на патч."""
+
+    def test_runtime_update_refreshes_cache_root(self) -> None:
+        with tempfile.TemporaryDirectory() as src_dir, tempfile.TemporaryDirectory() as initial_root, tempfile.TemporaryDirectory() as new_root:
+            module, folder_paths = _prepare_module(Path(initial_root), Path(src_dir))
+            _cleanup_module(self)
+
+            source_file = Path(src_dir) / "model.safetensors"
+            source_file.write_text("data", encoding="utf-8")
+
+            result = module.set_cache_settings(root=new_root, max_gb=5, enable=True, verbose=False)
+            self.assertTrue(result["ok"])
+            self.assertEqual(result["effective_root"], str(Path(new_root).resolve(strict=False)))
+
+            resolved = folder_paths.get_full_path("checkpoints", "model.safetensors")  # type: ignore[attr-defined]
+            expected_path = Path(new_root) / "checkpoints" / "model.safetensors"
+            self.assertEqual(Path(resolved).resolve(strict=False), expected_path.resolve(strict=False))
+            self.assertTrue(expected_path.exists())
+
+            paths_list = folder_paths.get_folder_paths("checkpoints")  # type: ignore[attr-defined]
+            first_path = Path(paths_list[0]).resolve(strict=False)
+            expected_category_root = (Path(new_root) / "checkpoints").resolve(strict=False)
+            self.assertEqual(first_path, expected_category_root)
+
+
+class ArenaAutoCacheEnableToggleTest(unittest.TestCase):
+    """RU: Проверяет отключение кеша и возврат оригинальных функций."""
+
+    def test_disable_restores_original_folder_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as src_dir, tempfile.TemporaryDirectory() as cache_root:
+            module, folder_paths = _prepare_module(Path(cache_root), Path(src_dir))
+            _cleanup_module(self)
+
+            self.assertIsNot(folder_paths.get_folder_paths, module._orig_get_folder_paths)  # type: ignore[attr-defined]
+            self.assertIsNot(folder_paths.get_full_path, module._orig_get_full_path)  # type: ignore[attr-defined]
+
+            module.set_cache_settings(enable=False)
+
+            self.assertIs(folder_paths.get_folder_paths, module._orig_get_folder_paths)  # type: ignore[attr-defined]
+            self.assertIs(folder_paths.get_full_path, module._orig_get_full_path)  # type: ignore[attr-defined]
+
+            stats_node = module.ArenaAutoCacheStats()
+            stats_json, = stats_node.run("checkpoints")
+            payload = json.loads(stats_json)
+            self.assertFalse(payload["enabled"])
+
+
+class ArenaAutoCacheStatsExTest(unittest.TestCase):
+    """RU: Проверяет расширенную статистику и счётчики сессии."""
+
+    def test_stats_ex_reports_session_counters(self) -> None:
+        with tempfile.TemporaryDirectory() as src_dir, tempfile.TemporaryDirectory() as cache_root:
+            module, folder_paths = _prepare_module(Path(cache_root), Path(src_dir))
+            _cleanup_module(self)
+
+            source_file = Path(src_dir) / "model.safetensors"
+            source_file.write_text("payload", encoding="utf-8")
+
+            folder_paths.get_full_path("checkpoints", "model.safetensors")  # type: ignore[attr-defined]
+            folder_paths.get_full_path("checkpoints", "model.safetensors")  # type: ignore[attr-defined]
+
+            stats_node = module.ArenaAutoCacheStatsEx()
+            stats_json, items, total_gb, cache_root_str, session_hits, session_misses, session_trims = stats_node.run("checkpoints")
+            payload = json.loads(stats_json)
+
+            self.assertEqual(items, payload["items"])
+            self.assertEqual(Path(cache_root_str).resolve(strict=False), Path(payload["cache_root"]).resolve(strict=False))
+            self.assertAlmostEqual(total_gb, payload["total_gb"])
+            self.assertGreaterEqual(session_hits, 1)
+            self.assertGreaterEqual(session_misses, 0)
+            self.assertGreaterEqual(session_trims, 0)
+
+            trim_node = module.ArenaAutoCacheTrim()
+            trim_json, = trim_node.run("checkpoints")
+            trim_payload = json.loads(trim_json)
+            self.assertTrue(trim_payload["ok"])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Summary:
Добавлены узлы: Arena AutoCache: Config / StatsEx / Manager.
Настройки кеша (путь, лимит, флаги) меняются в рантайме без перезапуска; патч folder_paths обновляется на лету.
Совместимость со старыми графами сохранена (старые Stats/Trim без изменений).
Добавлены счётчики сессии HIT/MISS/TRIM и расширенная статистика.
Changes:
custom_nodes/ComfyUI_Arena/autocache/arena_auto_cache.py — конфиг в dataclass, безопасный repatch, новые ноды.
tests/test_autocache_config.py и правки tests/test_arena_auto_cache.py — тесты.
custom_nodes/ComfyUI_Arena/README.md и README.md — документация.
Test Plan:
Локально: python -m unittest tests.test_autocache_config tests.test_arena_auto_cache.
В ComfyUI: поставить “Arena AutoCache: Config”, задать путь/лимит; проверить “Stats/StatsEx” и “Trim”.
Notes:
Нормализация путей Windows/UNC, операции под RLock, fallback если folder_paths недоступен.