### PR TITLE
Fix README encoding mojibake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Describe the expanded AutoCache stats and trim JSON payloads in `custom_nodes/ComfyUI_Arena/README.md`.
 - Reorganize documentation under `docs/ru` (with navigation and quickstart/config guides) and add English placeholders linked from the README.
 - Restructure `docs/ROADMAP.md` with detailed release milestones, ownership, and planning horizons.
+- Normalize `README.md` encoding and restore Russian workflow/docs text without mojibake.
 ### Fixed
 - Aggregate Arena node and display mapping exports at the package root so ComfyUI can discover nodes even when optional submodules fail to import.
 - Allow cache lookups to fall back to source files when `.copying` locks persist and clean up stale locks before retrying copies.

--- a/README.md
+++ b/README.md
@@ -1,36 +1,33 @@
-﻿# ComfyUI Arena Suite
+# ComfyUI Arena Suite
 
 Custom nodes for ComfyUI with the **Arena** prefix bundled in a **single package**.
 
 ## Features overview
-- **Legacy nodes** вЂ” migrated utilities that preserve the existing interfaces while living under `ComfyUI_Arena/legacy`.
+- **Legacy nodes** — migrated utilities that preserve the existing interfaces while living under `ComfyUI_Arena/legacy`.
 - **AutoCache** — runtime patch for `folder_paths` that prefers an SSD cache, plus Config/StatsEx/Trim/Manager nodes for in-graph control (see `custom_nodes/ComfyUI_Arena/README.md`).
-- **Updater scaffolding** вЂ” Hugging Face and CivitAI helpers (WIP) intended to keep local model folders in sync and manage `current` symlinks.
+- **Updater scaffolding** — Hugging Face and CivitAI helpers (WIP) intended to keep local model folders in sync and manage `current` symlinks.
 
 ## System requirements
 - **ComfyUI** with custom node support (tested on the current `master` branch).
 - **Python 3.10+** as required by `pyproject.toml`.
 - **Fast SSD storage** when enabling AutoCache to get the best throughput.
-- **[ComfyUI-Impact-Pack](https://github.com/ltdrdata/ComfyUI-Impact-Pack)** for legacy Arena nodes вЂ” install it via ComfyUI Manager or manually clone the repository so `ComfyUI-Impact-Pack/modules` is available on `PYTHONPATH`.
+- **[ComfyUI-Impact-Pack](https://github.com/ltdrdata/ComfyUI-Impact-Pack)** for legacy Arena nodes — install it via ComfyUI Manager or manually clone the repository so `ComfyUI-Impact-Pack/modules` is available on `PYTHONPATH`.
 
 ## Quick usage summary
-1. Install the suite through **ComfyUI Manager в†’ Install from URL** using your repository URL (for example, `https://github.com/<your-org>/comfyui-arena-suite`).
+1. Install the suite through **ComfyUI Manager → Install from URL** using your repository URL (for example, `https://github.com/<your-org>/comfyui-arena-suite`).
 2. Refresh the custom nodes list or restart ComfyUI so the new Arena nodes load.
 3. Drop nodes with the **Arena** prefix into your graph to verify the installation (e.g., `ArenaAutoCacheStats`).
-4. Configure SSD caching and update manifests as needed вЂ” see the documentation below for detailed steps.
+4. Configure SSD caching and update manifests as needed — see the documentation below for detailed steps.
 
 ## Documentation
-- рџ‡·рџ‡є Р СѓСЃСЃРєР°СЏ РґРѕРєСѓРјРµРЅС‚Р°С†РёСЏ: [РћР±Р·РѕСЂ](docs/ru/index.md), [Р‘С‹СЃС‚СЂС‹Р№ СЃС‚Р°СЂС‚](docs/ru/quickstart.md), [CLI](docs/ru/cli.md), [РљРѕРЅС„РёРіСѓСЂР°С†РёСЏ](docs/ru/config.md), [Р”РёР°РіРЅРѕСЃС‚РёРєР°](docs/ru/troubleshooting.md).
-- рџ‡¬рџ‡§ English placeholders: [Overview](docs/en/index.md), [Quickstart](docs/en/quickstart.md), [CLI](docs/en/cli.md), [Configuration](docs/en/config.md),
-- [Troubleshooting](docs/en/troubleshooting.md).
+- 🇷🇺 Русская документация: [Обзор](docs/ru/index.md), [Быстрый старт](docs/ru/quickstart.md), [CLI](docs/ru/cli.md), [Конфигурация](docs/ru/config.md), [Диагностика](docs/ru/troubleshooting.md).
+- 🇬🇧 English placeholders: [Overview](docs/en/index.md), [Quickstart](docs/en/quickstart.md), [CLI](docs/en/cli.md), [Configuration](docs/en/config.md), [Troubleshooting](docs/en/troubleshooting.md).
 - [Agents rules](AGENTS.md) - guidelines for developing and integrating Codex & ComfyUI agents.
 
 ## Codex workflow
-1. odex РіРµРЅРµСЂРёСЂСѓРµС‚ РєРѕРґ (EN identifiers, RU comments).
-2. РЎРѕР·РґР°С‘С‚/РѕР±РЅРѕРІР»СЏРµС‚ Issue: `Codex: <module> вЂ” <topic> вЂ” <date>` СЃ Р±Р»РѕРєР°РјРё
-   **SUMMARY / ISSUES & TASKS / TEST PLAN / NOTES**.
-3. Р’СЃРµ РёР·РјРµРЅРµРЅРёСЏ РёРґСѓС‚ С‡РµСЂРµР· PR; С‚РµР»Рѕ PR вЂ” РїРѕ С€Р°Р±Р»РѕРЅСѓ (СЃРј. `.github/pull_request_template.md`).
-4. Р’ РєРѕРјРјРёС‚Р°С… СЃСЃС‹Р»Р°С‚СЊСЃСЏ РЅР° Issue: `Refs #<РЅРѕРјРµСЂ>`.
-5. CHANGELOG (`[Unreleased]`) Рё docs РѕР±РЅРѕРІР»СЏСЋС‚СЃСЏ РІ С‚РѕРј Р¶Рµ PR.
-
+1. Codex генерирует код (EN identifiers, RU comments).
+2. Создаёт/обновляет Issue: `Codex: <module> — <topic> — <date>` с блоками **SUMMARY / ISSUES & TASKS / TEST PLAN / NOTES**.
+3. Все изменения идут через PR; тело PR — по шаблону (см. `.github/pull_request_template.md`).
+4. В коммитах ссылаться на Issue: `Refs #<номер>`.
+5. CHANGELOG (`[Unreleased]`) и docs обновляются в том же PR.
 


### PR DESCRIPTION
## Summary
- Normalize the repository README encoding to remove the stray BOM
- Restore the Russian documentation links and Codex workflow text with proper em-dashes

## Changes
- Re-encode `README.md` as UTF-8 without BOM and fix mojibake fragments
- Update `CHANGELOG.md` to record the documentation cleanup

## Docs
- README.md

## Changelog
- Added entry under `[Unreleased]` → Docs noting the README normalization

## Test Plan
1. Open `README.md` in a UTF-8 viewer and verify Russian text renders without mojibake artifacts.
2. Run `python - <<'PY'` snippet to confirm the file header bytes do not include a BOM (`b'# C'` expected).
3. Execute `rg "вЂ" -n` and `rg "Р\xa0" -n` to ensure no residual mojibake tokens remain in the repo.

## Risks
- Low: documentation-only update.

## Rollback
- Revert this commit to restore the previous README and changelog state.

## Checklist
- [ ] Tests added/updated
- [x] Docs updated
- [x] Changelog updated
- [x] Formatting conventions satisfied
- [x] CI expected to remain green

------
https://chatgpt.com/codex/tasks/task_b_68ce8f6ec5cc8324a8a32f4c383d9947