### PR TITLE
feat(autocache): add audit and warmup helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add Arena AutoCache audit/warmup helpers with unified item spec parsing and JSON reports.
 ### Changed
 - Extend Arena AutoCache index metadata to expose byte totals and the last HIT/MISS/TRIM/COPY event.
 ### Docs

--- a/__init__.py
+++ b/__init__.py
@@ -2,7 +2,14 @@
 
 from importlib import import_module as _import_module
 
-_arena_module = _import_module(".custom_nodes.ComfyUI_Arena", __name__)
+_base_package = __name__
+if _base_package in {"__main__", "__init__"}:
+    _base_package = "comfyui_arena_suite"
+
+try:
+    _arena_module = _import_module(".custom_nodes.ComfyUI_Arena", _base_package)
+except ModuleNotFoundError:
+    _arena_module = _import_module("custom_nodes.ComfyUI_Arena")
 
 _export_names = getattr(_arena_module, "__all__", None)
 if _export_names is None:
@@ -12,6 +19,6 @@ globals().update({name: getattr(_arena_module, name) for name in _export_names})
 __all__ = tuple(_export_names)
 
 # RU: подчистим временные переменные, чтобы не светились наружу
-for _name in ("_import_module", "_arena_module", "_export_names"):
+for _name in ("_import_module", "_arena_module", "_export_names", "_base_package"):
     globals().pop(_name, None)
 del _name

--- a/docs/en/nodes.md
+++ b/docs/en/nodes.md
@@ -49,6 +49,36 @@ Extended statistics node with dedicated sockets for numeric values and session c
   - `INT` (`session_misses`) — session miss counter.
   - `INT` (`session_trims`) — session trim counter.
 
+### ArenaAutoCacheAudit
+
+Checks whether source models exist and whether the cache already contains the corresponding files. Supports `items` lists (newline separated strings or JSON arrays) and auto-discovery from `workflow_json`. Only filenames with typical model extensions (`.safetensors`, `.ckpt`, `.pt`, `.pth`, `.onnx`, `.vae`, `.bin`, `.gguf`, `.yaml`, `.yml`, `.npz`, `.pb`, `.tflite`) are considered.
+
+- **Inputs**
+  - `items` (`STRING`, multiline) — `category:file` strings or a JSON array of strings/objects with `category` + `name`/`filename`.
+  - `workflow_json` (`STRING`, multiline) — optional workflow JSON dump for automatic discovery.
+  - `default_category` (`STRING`, default `"checkpoints"`) — fallback category when not specified.
+- **Outputs**
+  - `STRING` (`json`) — report listing each item with `cached`, `missing_cache`, `missing_source` statuses and aggregated `counts`.
+  - `INT` (`total`) — number of unique entries in the report.
+  - `INT` (`cached`) — entries already present in the cache.
+  - `INT` (`missing`) — entries missing either from the cache or from the source directories.
+
+### ArenaAutoCacheWarmup
+
+Warms up the cache using the same `items`/`workflow_json` specification. The node ensures free space via `_lru_ensure_room`, copies missing files and updates the cache index (`_update_index_touch`, `_update_index_meta`).
+
+- **Inputs**
+  - `items` (`STRING`, multiline) — warmup targets (strings or JSON, identical to `Audit`).
+  - `workflow_json` (`STRING`, multiline) — optional workflow JSON dump.
+  - `default_category` (`STRING`, default `"checkpoints"`).
+- **Outputs**
+  - `STRING` (`json`) — execution report with per-item statuses (`copied`, `cached`, `missing_source`, `error_*`) and aggregated counters `warmed`, `copied`, `missing`, `errors`, `skipped`.
+  - `INT` (`total`) — number of processed entries.
+  - `INT` (`warmed`) — entries now cached.
+  - `INT` (`copied`) — files copied during warmup.
+  - `INT` (`missing`) — entries skipped because the source file is missing.
+  - `INT` (`errors`) — failures such as trimming/copy errors.
+
 ### ArenaAutoCacheTrim
 
 Manually runs the LRU maintenance routine for the selected category.

--- a/docs/ru/nodes.md
+++ b/docs/ru/nodes.md
@@ -49,6 +49,36 @@ description: "Описание входов и выходов узлов ComfyUI
   - `INT` (`session_misses`) — промахи за текущую сессию.
   - `INT` (`session_trims`) — ручные или автоматические очистки за текущую сессию.
 
+### ArenaAutoCacheAudit
+
+Проверяет, существуют ли исходные модели и есть ли соответствующие файлы в кэше. Поддерживает списки `items` (по строкам или JSON) и извлечение имён из `workflow_json`; учитываются расширения `.safetensors`, `.ckpt`, `.pt`, `.pth`, `.onnx`, `.vae`, `.bin`, `.gguf`, `.yaml`, `.yml`, `.npz`, `.pb`, `.tflite`.
+
+- **Входы**
+  - `items` (`STRING`, многострочный) — строки `category:file` либо JSON-массив строк/объектов с ключами `category`, `name`/`filename`.
+  - `workflow_json` (`STRING`, многострочный) — опционально: полный JSON сохранённого workflow для авто-добавления моделей.
+  - `default_category` (`STRING`, по умолчанию `"checkpoints"`) — категория по умолчанию.
+- **Выходы**
+  - `STRING` (`json`) — отчёт со статусами `cached`, `missing_cache`, `missing_source` и агрегатом `counts`.
+  - `INT` (`total`) — уникальные элементы в отчёте.
+  - `INT` (`cached`) — элементы, найденные в кэше.
+  - `INT` (`missing`) — отсутствующие элементы (в кэше или на источнике).
+
+### ArenaAutoCacheWarmup
+
+Использует ту же спецификацию `items`/`workflow_json`, но прогревает кэш: освобождает место, копирует отсутствующие файлы и обновляет индекс (`_update_index_touch`, `_update_index_meta`).
+
+- **Входы**
+  - `items` (`STRING`, многострочный) — перечень моделей (строки или JSON, как в `Audit`).
+  - `workflow_json` (`STRING`, многострочный) — опционально: JSON workflow.
+  - `default_category` (`STRING`, по умолчанию `"checkpoints"`).
+- **Выходы**
+  - `STRING` (`json`) — отчёт с поэлементными статусами (`copied`, `cached`, `missing_source`, `error_*`) и суммарными счётчиками `warmed`, `copied`, `missing`, `errors`, `skipped`.
+  - `INT` (`total`) — количество обработанных записей.
+  - `INT` (`warmed`) — элементы, оказавшиеся в кэше.
+  - `INT` (`copied`) — количество копий.
+  - `INT` (`missing`) — отсутствующие исходники.
+  - `INT` (`errors`) — возникшие ошибки.
+
 ### ArenaAutoCacheTrim
 
 Запускает ручное обслуживание LRU-кэша для указанной категории.

--- a/tests/test_autocache_warmup.py
+++ b/tests/test_autocache_warmup.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+MODULE_NAME = "custom_nodes.ComfyUI_Arena.autocache.arena_auto_cache"
+
+
+class ArenaAutoCacheParseItemsSpecTest(unittest.TestCase):
+    """Validate unified item specification parsing."""
+
+    def tearDown(self) -> None:  # noqa: D401 - unittest hook
+        sys.modules.pop(MODULE_NAME, None)
+
+    def test_parse_items_spec_merges_sources_and_deduplicates(self) -> None:
+        module = importlib.import_module(MODULE_NAME)
+        items = "\n".join([
+            "loras:style.safetensors",
+            "checkpoints:model.safetensors",
+        ])
+        workflow = json.dumps(
+            {
+                "nodes": [
+                    {
+                        "class_type": "CheckpointLoaderSimple",
+                        "inputs": {"ckpt_name": "model.safetensors"},
+                    },
+                    {"class_type": "VAELoader", "inputs": {"vae_name": "vae.pt"}},
+                    {"class_type": "LoraLoader", "inputs": {"lora_name": "style.safetensors"}},
+                ]
+            }
+        )
+
+        parsed = module.parse_items_spec(items, workflow, "checkpoints")
+
+        self.assertEqual(
+            parsed,
+            [
+                {"category": "loras", "name": "style.safetensors"},
+                {"category": "checkpoints", "name": "model.safetensors"},
+                {"category": "vae", "name": "vae.pt"},
+            ],
+        )
+
+
+class ArenaAutoCacheWarmupAuditIntegrationTest(unittest.TestCase):
+    """Integration tests for warmup/audit helpers operating on real files."""
+
+    def setUp(self) -> None:
+        self.addCleanup(sys.modules.pop, MODULE_NAME, None)
+        self.addCleanup(sys.modules.pop, "folder_paths", None)
+        self.addCleanup(lambda: os.environ.pop("ARENA_CACHE_ROOT", None))
+        self.addCleanup(lambda: os.environ.pop("ARENA_CACHE_ENABLE", None))
+        self.addCleanup(lambda: os.environ.pop("ARENA_CACHE_VERBOSE", None))
+
+    def _prepare_module(self, cache_root: Path, source_dir: Path):
+        folder_paths = types.ModuleType("folder_paths")
+
+        def _get_folder_paths(category: str):
+            if category in {"checkpoints", "loras"}:
+                return [str(source_dir)]
+            return []
+
+        def _get_full_path(category: str, name: str):
+            candidate = Path(source_dir) / name
+            return str(candidate) if candidate.exists() else None
+
+        folder_paths.get_folder_paths = _get_folder_paths  # type: ignore[attr-defined]
+        folder_paths.get_full_path = _get_full_path  # type: ignore[attr-defined]
+        sys.modules["folder_paths"] = folder_paths
+
+        os.environ["ARENA_CACHE_ROOT"] = str(cache_root)
+        os.environ["ARENA_CACHE_ENABLE"] = "1"
+        os.environ["ARENA_CACHE_VERBOSE"] = "0"
+
+        sys.modules.pop(MODULE_NAME, None)
+        module = importlib.import_module(MODULE_NAME)
+        module._STALE_LOCK_SECONDS = 0.01
+        return module
+
+    def test_warmup_populates_cache_and_audit_reports_statuses(self) -> None:
+        with tempfile.TemporaryDirectory() as src_dir, tempfile.TemporaryDirectory() as cache_root:
+            source_dir = Path(src_dir)
+            cache_root_path = Path(cache_root)
+            (source_dir / "model.safetensors").write_text("payload", encoding="utf-8")
+
+            module = self._prepare_module(cache_root_path, source_dir)
+
+            warmup_node = module.ArenaAutoCacheWarmup()
+            report_json, total, warmed, copied, missing, errors = warmup_node.run(
+                "checkpoints:model.safetensors\nloras:style.safetensors",
+                "",
+                "checkpoints",
+            )
+            payload = json.loads(report_json)
+
+            self.assertEqual(total, 2)
+            self.assertEqual(warmed, 1)
+            self.assertEqual(copied, 1)
+            self.assertEqual(missing, 1)
+            self.assertEqual(errors, 0)
+            self.assertTrue(payload["ok"])
+
+            cache_file = cache_root_path / "checkpoints" / "model.safetensors"
+            self.assertTrue(cache_file.exists())
+
+            audit_node = module.ArenaAutoCacheAudit()
+            audit_json, audit_total, cached, missing_count = audit_node.run(
+                "checkpoints:model.safetensors\nloras:style.safetensors",
+                "",
+                "checkpoints",
+            )
+            audit_payload = json.loads(audit_json)
+
+            self.assertEqual(audit_total, 2)
+            self.assertEqual(cached, 1)
+            self.assertEqual(missing_count, 1)
+            statuses = {item["name"]: item["status"] for item in audit_payload["items"]}
+            self.assertEqual(statuses["model.safetensors"], "cached")
+            self.assertEqual(statuses["style.safetensors"], "missing_source")
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
* add a reusable parser for AutoCache warmup/audit item specifications including workflow JSON discovery
* implement ArenaAutoCacheAudit and ArenaAutoCacheWarmup nodes with thread-safe cache maintenance and 🅰️ display names
* document the new helpers, extend the changelog and harden the package entry-point import fallback

## Changes
* parse string/JSON/workflow specs via `parse_items_spec` with extension filtering and deduplication
* add audit/warmup nodes that reuse the cache helper stack, emit JSON reports and update node mappings
* update docs, changelog, and package init to cover the new functionality and relative-import fallback
* create regression tests for parsing, warmup execution, and audit reporting

## Docs
* custom_nodes/ComfyUI_Arena/README.md
* docs/en/nodes.md
* docs/ru/nodes.md

## Changelog
* CHANGELOG.md `### Added` entry under `[Unreleased]`

## Test Plan
* python -m pytest (expect all seven tests to pass)

## Risks
* Medium – touches cache management logic and introduces new nodes; mitigated by unit tests and reuse of existing helpers.

## Rollback
* Revert the commit and remove the new nodes/mappings; restore previous docs and changelog entry.

## Checklist
- [x] Tests
- [x] Docs
- [x] Changelog
- [x] Formatting
- [x] CI green (or reason provided)


------
https://chatgpt.com/codex/tasks/task_b_68ceaabe69088324acc6278324595611