### PR TITLE
docs: expand autocache audit warmup guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Extend Arena AutoCache index metadata to expose byte totals and the last HIT/MISS/TRIM/COPY event.
 ### Docs
+- Expand the Audit/Warmup node docs with bilingual multiline/JSON examples and `workflow_json` guidance, and mention the nodes in the root README.
 - Publish bilingual node reference covering AutoCache and legacy tiles nodes in `custom_nodes/ComfyUI_Arena/README.md` and `docs/{ru,en}/nodes.md`.
 - Document the Impact Pack dependency and credit ltdrdata in the README install instructions.
 - Note that autocache nodes return disabled stubs when `ARENA_CACHE_ENABLE=0`.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Custom nodes for ComfyUI with the **Arena** prefix bundled in a **single package
 ## Features overview
 - **Legacy nodes** — migrated utilities that preserve the existing interfaces while living under `ComfyUI_Arena/legacy`.
 - **AutoCache** — runtime patch for `folder_paths` that prefers an SSD cache, plus Config/StatsEx/Trim/Manager nodes for in-graph control (see `custom_nodes/ComfyUI_Arena/README.md`).
+- **Audit & Warmup nodes** — verify and pre-fill the SSD cache via multiline lists or workflow JSON (see `custom_nodes/ComfyUI_Arena/README.md`). **RU:** Узлы Audit/Warmup проверяют и прогревают SSD-кэш, принимают многострочные списки и JSON из `workflow_json` экспорта.
 - **Updater scaffolding** — Hugging Face and CivitAI helpers (WIP) intended to keep local model folders in sync and manage `current` symlinks.
 
 ## System requirements

--- a/custom_nodes/ComfyUI_Arena/README.md
+++ b/custom_nodes/ComfyUI_Arena/README.md
@@ -103,6 +103,30 @@ Extended statistics with dedicated sockets for numeric values and session counte
   - `INT` (`total`) — количество уникальных записей в отчёте.
   - `INT` (`cached`) — число элементов, присутствующих в кэше.
   - `INT` (`missing`) — число элементов без кэша или без исходника.
+- **Примеры**
+  - Многострочный список c комментариями:
+
+    ```text
+    # checkpoints по умолчанию
+    anything-v4.5-pruned.ckpt
+    loras:korean-style.safetensors
+    checkpoints:refiner.safetensors
+    ```
+
+  - JSON-массив (поддерживает строки и объекты):
+
+    ```json
+    [
+      "loras:paper-cut.safetensors",
+      {
+        "category": "checkpoints",
+        "name": "base-model.safetensors",
+        "source": "/mnt/models/base-model.safetensors"
+      }
+    ]
+    ```
+
+  - Использование `workflow_json`: экспортируйте граф через **Queue → Save (API Format)**, загрузите файл с помощью стандартного `Load Text` и подключите его выход к `workflow_json`, чтобы узел автоматически добавил модели из workflow.
 
 **EN**
 
@@ -117,6 +141,30 @@ Traverses the provided item list, verifies that source files exist and the cache
   - `INT` (`total`) — number of unique entries covered by the audit.
   - `INT` (`cached`) — entries already cached.
   - `INT` (`missing`) — entries missing from cache or sources.
+- **Examples**
+  - Multiline list with inline comments:
+
+    ```text
+    # default checkpoints category
+    anything-v4.5-pruned.ckpt
+    loras:korean-style.safetensors
+    checkpoints:refiner.safetensors
+    ```
+
+  - JSON payload (mixing strings and objects):
+
+    ```json
+    [
+      "loras:paper-cut.safetensors",
+      {
+        "category": "checkpoints",
+        "name": "base-model.safetensors",
+        "source": "/mnt/models/base-model.safetensors"
+      }
+    ]
+    ```
+
+  - `workflow_json` hookup: export the graph via **Queue → Save (API Format)**, load the file with the built-in `Load Text` node and feed its output into `workflow_json` so the audit adds every model referenced in the workflow automatically.
 
 ### ArenaAutoCacheWarmup
 
@@ -135,6 +183,9 @@ Traverses the provided item list, verifies that source files exist and the cache
   - `INT` (`copied`) — сколько файлов пришлось копировать заново.
   - `INT` (`missing`) — сколько записей не удалось подготовить из-за отсутствующих исходников.
   - `INT` (`errors`) — количество ошибок (например, нехватка места или сбой копирования).
+- **Примеры**
+  - Формат `items` полностью совпадает с `Audit`, поэтому можно переиспользовать список или JSON из предыдущего примера.
+  - Чтобы прогреть модели из текущего графа, подключите тот же `Load Text` с экспортированным workflow к `workflow_json` и, при необходимости, добавьте вручную элементы, которых нет в workflow.
 
 **EN**
 
@@ -151,6 +202,9 @@ Warms up the cache using the same `items`/`workflow_json` specification. For eve
   - `INT` (`copied`) — files copied during the warmup.
   - `INT` (`missing`) — entries skipped because the source file is missing.
   - `INT` (`errors`) — number of failures (lack of space, copy errors, etc.).
+- **Examples**
+  - The `items` format mirrors the audit node, so you can reuse the multiline list or JSON payload shown above.
+  - To warm up every model referenced in the current workflow, feed the exported JSON (via `Load Text` or any text loader) into `workflow_json` and optionally append manual entries for assets that live outside the workflow.
 
 ### ArenaAutoCacheTrim
 


### PR DESCRIPTION
## Summary
- Expand the AutoCache audit/warmup documentation with bilingual examples and workflow_json guidance.

## Changes
- Document multiline lists and JSON specs for the Audit/Warmup nodes in both Russian and English sections.
- Explain how to feed exported workflow_json data via Load Text to extend the audited/warmed model set.
- Mention the new Audit/Warmup helpers in the root README feature list.

## Docs
- custom_nodes/ComfyUI_Arena/README.md
- README.md

## Changelog
- Added a Docs bullet under [Unreleased] covering the expanded guidance.

## Test Plan
- [ ] Open `custom_nodes/ComfyUI_Arena/README.md` and verify the RU/EN sections render the new examples.
- [ ] Open the root README features list and confirm the Audit/Warmup note appears with RU context.

## Risks
- Low — documentation-only change.

## Rollback
- Revert commit `docs: expand autocache audit warmup guidance`.

## Checklist
- [ ] Tests
- [x] Docs
- [x] Changelog
- [x] Formatting
- [ ] CI green

------
https://chatgpt.com/codex/tasks/task_b_68ceb06a74c8832496ac055322c1ae4f