### PR TITLE
docs: note audit and warmup nodes in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Introduce dedicated Audit and Warmup nodes together with a companion CLI utility so users can inspect and prefill Arena caches directly from ComfyUI or automation scripts.
 - Add Arena AutoCache audit/warmup helpers with unified item spec parsing and JSON reports.
 - Add regression tests covering Arena AutoCache audit and warmup flows.
 ### Changed


### PR DESCRIPTION
## Summary
- document the arrival of the Audit and Warmup nodes and their utility helper in the unreleased changelog

## Changes
- add a Keep a Changelog entry that highlights the new nodes and CLI utility for Arena cache workflows

## Docs
- n/a

## Changelog
- note the new Audit/Warmup nodes and companion utility under `[Unreleased]`

## Test Plan
- not run (documentation-only change)

## Risks
- Low; text-only change

## Rollback
- Revert this commit

## Checklist
- [ ] Tests
- [ ] Docs
- [x] Changelog
- [ ] Formatting
- [ ] CI green

------
https://chatgpt.com/codex/tasks/task_b_68ceb16310bc8324b09663fc8ca529d9