### PR TITLE
chore(autocache): enrich node metadata localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extend Arena AutoCache index metadata to expose byte totals and the last HIT/MISS/TRIM/COPY event.
 - Prefix Arena AutoCache and legacy tiles node display names with the 🅰️ marker for consistent UI grouping.
 - Localize AutoCache node labels and I/O names based on the `ARENA_LANG` environment variable.
+- Enrich Arena AutoCache nodes with localized descriptions, tooltips, and output metadata for ComfyUI.
 ### Docs
 - Expand the Audit/Warmup node docs with bilingual multiline/JSON examples and `workflow_json` guidance, and mention the nodes in the root README.
 - Publish bilingual node reference covering AutoCache and legacy tiles nodes in `custom_nodes/ComfyUI_Arena/README.md` and `docs/{ru,en}/nodes.md`.

--- a/custom_nodes/ComfyUI_Arena/autocache/arena_auto_cache.py
+++ b/custom_nodes/ComfyUI_Arena/autocache/arena_auto_cache.py
@@ -969,7 +969,11 @@ class ArenaAutoCacheConfig:
             "required": {
                 "cache_root": (
                     "STRING",
-                    {"default": str(settings.root), "tooltip": t("input.cache_root")},
+                    {
+                        "default": str(settings.root),
+                        "description": t("input.cache_root"),
+                        "tooltip": t("input.cache_root"),
+                    },
                 ),
                 "max_size_gb": (
                     "INT",
@@ -978,24 +982,36 @@ class ArenaAutoCacheConfig:
                         "min": 0,
                         "max": 4096,
                         "step": 1,
+                        "description": t("input.max_size_gb"),
                         "tooltip": t("input.max_size_gb"),
                     },
                 ),
                 "enable": (
                     "BOOLEAN",
-                    {"default": settings.enable, "tooltip": t("input.enable")},
+                    {
+                        "default": settings.enable,
+                        "description": t("input.enable"),
+                        "tooltip": t("input.enable"),
+                    },
                 ),
                 "verbose": (
                     "BOOLEAN",
-                    {"default": settings.verbose, "tooltip": t("input.verbose")},
+                    {
+                        "default": settings.verbose,
+                        "description": t("input.verbose"),
+                        "tooltip": t("input.verbose"),
+                    },
                 ),
             }
         }
 
     RETURN_TYPES = ("STRING",)
     RETURN_NAMES = (t("output.json"),)
+    RETURN_DESCRIPTIONS = (t("output.json"),)
+    OUTPUT_TOOLTIPS = RETURN_DESCRIPTIONS
     FUNCTION = "apply"
     CATEGORY = "Arena/AutoCache"
+    DESCRIPTION = t("node.config")
 
     def apply(self, cache_root: str, max_size_gb: int, enable: bool, verbose: bool):
         root_value = cache_root.strip()
@@ -1021,15 +1037,22 @@ class ArenaAutoCacheStats:
             "required": {
                 "category": (
                     "STRING",
-                    {"default": "checkpoints", "tooltip": t("input.category")},
+                    {
+                        "default": "checkpoints",
+                        "description": t("input.category"),
+                        "tooltip": t("input.category"),
+                    },
                 )
             }
         }
 
     RETURN_TYPES = ("STRING",)
     RETURN_NAMES = (t("output.json"),)
+    RETURN_DESCRIPTIONS = (t("output.json"),)
+    OUTPUT_TOOLTIPS = RETURN_DESCRIPTIONS
     FUNCTION = "run"
     CATEGORY = "Arena/AutoCache"
+    DESCRIPTION = t("node.stats")
 
     def run(self, category: str):
         data, _, _, _, _ = _collect_stats(category)
@@ -1045,7 +1068,11 @@ class ArenaAutoCacheStatsEx:
             "required": {
                 "category": (
                     "STRING",
-                    {"default": "checkpoints", "tooltip": t("input.category")},
+                    {
+                        "default": "checkpoints",
+                        "description": t("input.category"),
+                        "tooltip": t("input.category"),
+                    },
                 )
             }
         }
@@ -1060,8 +1087,19 @@ class ArenaAutoCacheStatsEx:
         t("output.session_misses"),
         t("output.session_trims"),
     )
+    RETURN_DESCRIPTIONS = (
+        t("output.json"),
+        t("output.items"),
+        t("output.total_gb"),
+        t("output.cache_root"),
+        t("output.session_hits"),
+        t("output.session_misses"),
+        t("output.session_trims"),
+    )
+    OUTPUT_TOOLTIPS = RETURN_DESCRIPTIONS
     FUNCTION = "run"
     CATEGORY = "Arena/AutoCache"
+    DESCRIPTION = t("node.statsex")
 
     def run(self, category: str):
         data, root, items, total_gb, counters = _collect_stats(category)
@@ -1089,6 +1127,7 @@ class ArenaAutoCacheAudit:
                     {
                         "default": "",
                         "multiline": True,
+                        "description": t("input.items"),
                         "tooltip": t("input.items"),
                     },
                 ),
@@ -1097,12 +1136,17 @@ class ArenaAutoCacheAudit:
                     {
                         "default": "",
                         "multiline": True,
+                        "description": t("input.workflow_json"),
                         "tooltip": t("input.workflow_json"),
                     },
                 ),
                 "default_category": (
                     "STRING",
-                    {"default": "checkpoints", "tooltip": t("input.default_category")},
+                    {
+                        "default": "checkpoints",
+                        "description": t("input.default_category"),
+                        "tooltip": t("input.default_category"),
+                    },
                 ),
             }
         }
@@ -1114,8 +1158,16 @@ class ArenaAutoCacheAudit:
         t("output.cached"),
         t("output.missing"),
     )
+    RETURN_DESCRIPTIONS = (
+        t("output.json"),
+        t("output.total"),
+        t("output.cached"),
+        t("output.missing"),
+    )
+    OUTPUT_TOOLTIPS = RETURN_DESCRIPTIONS
     FUNCTION = "run"
     CATEGORY = "Arena/AutoCache"
+    DESCRIPTION = t("node.audit")
 
     def run(self, items: str, workflow_json: str, default_category: str):
         module = _ensure_folder_paths_module()
@@ -1230,6 +1282,7 @@ class ArenaAutoCacheWarmup:
                     {
                         "default": "",
                         "multiline": True,
+                        "description": t("input.items"),
                         "tooltip": t("input.items"),
                     },
                 ),
@@ -1238,12 +1291,17 @@ class ArenaAutoCacheWarmup:
                     {
                         "default": "",
                         "multiline": True,
+                        "description": t("input.workflow_json"),
                         "tooltip": t("input.workflow_json"),
                     },
                 ),
                 "default_category": (
                     "STRING",
-                    {"default": "checkpoints", "tooltip": t("input.default_category")},
+                    {
+                        "default": "checkpoints",
+                        "description": t("input.default_category"),
+                        "tooltip": t("input.default_category"),
+                    },
                 ),
             }
         }
@@ -1257,8 +1315,18 @@ class ArenaAutoCacheWarmup:
         t("output.missing"),
         t("output.errors"),
     )
+    RETURN_DESCRIPTIONS = (
+        t("output.json"),
+        t("output.total"),
+        t("output.warmed"),
+        t("output.copied"),
+        t("output.missing"),
+        t("output.errors"),
+    )
+    OUTPUT_TOOLTIPS = RETURN_DESCRIPTIONS
     FUNCTION = "run"
     CATEGORY = "Arena/AutoCache"
+    DESCRIPTION = t("node.warmup")
 
     def run(self, items: str, workflow_json: str, default_category: str):
         module = _ensure_folder_paths_module()
@@ -1466,15 +1534,22 @@ class ArenaAutoCacheTrim:
             "required": {
                 "category": (
                     "STRING",
-                    {"default": "checkpoints", "tooltip": t("input.category")},
+                    {
+                        "default": "checkpoints",
+                        "description": t("input.category"),
+                        "tooltip": t("input.category"),
+                    },
                 )
             }
         }
 
     RETURN_TYPES = ("STRING",)
     RETURN_NAMES = (t("output.json"),)
+    RETURN_DESCRIPTIONS = (t("output.json"),)
+    OUTPUT_TOOLTIPS = RETURN_DESCRIPTIONS
     FUNCTION = "run"
     CATEGORY = "Arena/AutoCache"
+    DESCRIPTION = t("node.trim")
 
     def run(self, category: str):
         data = _trim_category(category)
@@ -1491,7 +1566,11 @@ class ArenaAutoCacheManager:
             "required": {
                 "cache_root": (
                     "STRING",
-                    {"default": str(settings.root), "tooltip": t("input.cache_root")},
+                    {
+                        "default": str(settings.root),
+                        "description": t("input.cache_root"),
+                        "tooltip": t("input.cache_root"),
+                    },
                 ),
                 "max_size_gb": (
                     "INT",
@@ -1500,32 +1579,52 @@ class ArenaAutoCacheManager:
                         "min": 0,
                         "max": 4096,
                         "step": 1,
+                        "description": t("input.max_size_gb"),
                         "tooltip": t("input.max_size_gb"),
                     },
                 ),
                 "enable": (
                     "BOOLEAN",
-                    {"default": settings.enable, "tooltip": t("input.enable")},
+                    {
+                        "default": settings.enable,
+                        "description": t("input.enable"),
+                        "tooltip": t("input.enable"),
+                    },
                 ),
                 "verbose": (
                     "BOOLEAN",
-                    {"default": settings.verbose, "tooltip": t("input.verbose")},
+                    {
+                        "default": settings.verbose,
+                        "description": t("input.verbose"),
+                        "tooltip": t("input.verbose"),
+                    },
                 ),
                 "category": (
                     "STRING",
-                    {"default": "checkpoints", "tooltip": t("input.category")},
+                    {
+                        "default": "checkpoints",
+                        "description": t("input.category"),
+                        "tooltip": t("input.category"),
+                    },
                 ),
                 "do_trim": (
                     "BOOLEAN",
-                    {"default": False, "tooltip": t("input.do_trim")},
+                    {
+                        "default": False,
+                        "description": t("input.do_trim"),
+                        "tooltip": t("input.do_trim"),
+                    },
                 ),
             }
         }
 
     RETURN_TYPES = ("STRING", "STRING")
     RETURN_NAMES = (t("output.stats_json"), t("output.action_json"))
+    RETURN_DESCRIPTIONS = (t("output.stats_json"), t("output.action_json"))
+    OUTPUT_TOOLTIPS = RETURN_DESCRIPTIONS
     FUNCTION = "manage"
     CATEGORY = "Arena/AutoCache"
+    DESCRIPTION = t("node.manager")
 
     def manage(
         self,


### PR DESCRIPTION
## Summary
- enrich Arena AutoCache nodes with localized descriptions and tooltips
- expose RETURN_DESCRIPTIONS/OUTPUT_TOOLTIPS metadata aligned with existing outputs
- document the localized metadata update in the changelog

## Changes
- add DESCRIPTION attributes and localized metadata across Arena AutoCache nodes
- augment input specs with localized descriptions and matching tooltips
- define RETURN_DESCRIPTIONS and OUTPUT_TOOLTIPS tuples for every Arena AutoCache node output

## Docs
- N/A

## Changelog
- CHANGELOG.md

## Test Plan
1. Start ComfyUI with this branch and ensure Arena AutoCache nodes display the localized description in the node header.
2. Open each Arena AutoCache node configuration panel and confirm every input shows the localized description and tooltip text.
3. Hover over each Arena AutoCache node output socket to verify the localized tooltip text matches the exposed metadata.
4. Set `ARENA_LANG=ru` and reload ComfyUI to confirm the Russian descriptions and tooltips render correctly.
5. Trigger AutoCache node execution to check the localized output tooltips still align with the returned data types.
6. Inspect the changelog entry under `[Unreleased]` for the metadata update summary.

## Risks
- Low: metadata-only changes with no functional logic updates.

## Rollback
- Revert this PR and reload ComfyUI to restore previous node metadata.

## Checklist
- [x] Tests
- [ ] Docs
- [x] Changelog
- [x] Formatting
- [x] CI green (or not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68cec9680ce8832490b63e2544442e29