### PR TITLE
feat: let comfyui lang override arena locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prefix Arena AutoCache and legacy tiles node display names with the 🅰️ marker for consistent UI grouping.
 - Localize AutoCache node labels and I/O names based on the `ARENA_LANG` environment variable.
 - Enrich Arena AutoCache nodes with localized descriptions, tooltips, and output metadata for ComfyUI.
+- Allow `COMFYUI_LANG` to override the AutoCache localization fallback before `ARENA_LANG`.
 ### Docs
 - Expand the Audit/Warmup node docs with bilingual multiline/JSON examples and `workflow_json` guidance, and mention the nodes in the root README.
 - Publish bilingual node reference covering AutoCache and legacy tiles nodes in `custom_nodes/ComfyUI_Arena/README.md` and `docs/{ru,en}/nodes.md`.

--- a/custom_nodes/ComfyUI_Arena/autocache/arena_auto_cache.py
+++ b/custom_nodes/ComfyUI_Arena/autocache/arena_auto_cache.py
@@ -9,11 +9,22 @@ from pathlib import Path
 from types import ModuleType
 from typing import Callable, Optional
 
-ARENA_LANG = (os.getenv("ARENA_LANG", "en") or "en").strip().lower()
-if "_" in ARENA_LANG:
-    ARENA_LANG = ARENA_LANG.split("_", 1)[0]
-if "-" in ARENA_LANG:
-    ARENA_LANG = ARENA_LANG.split("-", 1)[0]
+def _normalize_lang(value: str | None) -> str | None:
+    if not value:
+        return None
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    if "_" in normalized:
+        normalized = normalized.split("_", 1)[0]
+    if "-" in normalized:
+        normalized = normalized.split("-", 1)[0]
+    return normalized or None
+
+
+_comfyui_lang = _normalize_lang(os.getenv("COMFYUI_LANG"))
+_arena_lang = _normalize_lang(os.getenv("ARENA_LANG")) or "en"
+ARENA_LANG = _comfyui_lang or _arena_lang
 
 I18N: dict[str, dict[str, str]] = {
     "en": {


### PR DESCRIPTION
## Summary
- prioritize the COMFYUI_LANG environment variable when selecting the Arena AutoCache locale

## Changes
- add a shared normalization helper used for both COMFYUI_LANG and ARENA_LANG reads
- keep the existing fallback normalization and default language behaviour when neither variable is set
- document the new precedence in the changelog

## Docs
- N/A

## Changelog
- Updated `[Unreleased]` → `Changed`

## Test Plan
- Launch ComfyUI with `COMFYUI_LANG=ru-RU` and confirm Arena AutoCache nodes render with Russian labels without changing ARENA_LANG
- Launch ComfyUI with `COMFYUI_LANG` unset and `ARENA_LANG=es-ES`; verify nodes fall back to Spanish locale prefix (if available) and default to English otherwise
- Run `python -m compileall custom_nodes/ComfyUI_Arena/autocache/arena_auto_cache.py` to ensure the module compiles

## Risks
- Low: environment variable precedence adjustments only affect language selection on startup

## Rollback
- Revert this commit to restore the previous ARENA_LANG-only precedence

## Checklist
- [x] Tests
- [ ] Docs
- [x] Changelog
- [x] Formatting
- [ ] CI green

------
https://chatgpt.com/codex/tasks/task_b_68ced26c5cf48324adc8cfba332a471c