### PR TITLE
fix: update tiles segs node category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Localize AutoCache node labels and I/O names based on the `ARENA_LANG` environment variable.
 - Enrich Arena AutoCache nodes with localized descriptions, tooltips, and output metadata for ComfyUI.
 - Allow `COMFYUI_LANG` to override the AutoCache localization fallback before `ARENA_LANG`.
+- Set the legacy tiles segmentation node category to `Arena/Tiles` for improved UI grouping.
 ### Docs
 - Expand the Audit/Warmup node docs with bilingual multiline/JSON examples and `workflow_json` guidance, and mention the nodes in the root README.
 - Publish bilingual node reference covering AutoCache and legacy tiles nodes in `custom_nodes/ComfyUI_Arena/README.md` and `docs/{ru,en}/nodes.md`.

--- a/custom_nodes/ComfyUI_Arena/legacy/arena_make_tiles_segs.py
+++ b/custom_nodes/ComfyUI_Arena/legacy/arena_make_tiles_segs.py
@@ -39,7 +39,7 @@ class Arena_MakeTilesSegs:
 
     RETURN_TYPES = ("SEGS",)
     FUNCTION = "doit"
-    CATEGORY = "Arena/arenanodes"
+    CATEGORY = "Arena/Tiles"
 
     @staticmethod
     def doit(images, width, height, crop_factor, min_overlap, filter_segs_dilation, mask_irregularity=0, irregular_mask_mode="Reuse fast", filter_in_segs_opt=None, filter_out_segs_opt=None):


### PR DESCRIPTION
## Summary
- update the legacy tiles segmentation node category to "Arena/Tiles" to reflect the new grouping (no issue link)

## Changes
- adjust `Arena_MakeTilesSegs.CATEGORY` to use the `Arena/Tiles` bucket
- document the category update in the `[Unreleased]` changelog section

## Docs
- CHANGELOG.md

## Changelog
- Added an `[Unreleased]` entry noting the legacy tiles segmentation node category update

## Test Plan
- Not run (metadata/category update only)

## Risks
- Minimal: incorrect category string could hide the node in the ComfyUI UI

## Rollback
- Revert commits `cb80b8f` and `9f7d177`

## Ideas
- None at this time


------
https://chatgpt.com/codex/tasks/task_b_68ced99e77b08324ac73b42777525d34