### PR TITLE
fix: расширены аргументы аудита автокэша

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add regression tests covering Arena AutoCache audit and warmup flows.
 - Add Arena AutoCache dashboard and ops nodes with mode selection, benchmarking toggles, and dedicated smoke tests.
 ### Changed
+- Prepare the AutoCache Audit node to accept extended stats and settings override arguments without altering current behaviour.
 - Extend Arena AutoCache index metadata to expose byte totals and the last HIT/MISS/TRIM/COPY event.
 - Prefix Arena AutoCache and legacy tiles node display names with the 🅰️ marker for consistent UI grouping.
 - Localize AutoCache node labels and I/O names based on the `ARENA_LANG` environment variable.

--- a/custom_nodes/ComfyUI_Arena/autocache/arena_auto_cache.py
+++ b/custom_nodes/ComfyUI_Arena/autocache/arena_auto_cache.py
@@ -1778,7 +1778,17 @@ class ArenaAutoCacheAudit:
     CATEGORY = "Arena/AutoCache"
     DESCRIPTION = t("node.audit")
 
-    def run(self, items: str, workflow_json: str, default_category: str):
+    def run(
+        self,
+        items: str,
+        workflow_json: str,
+        default_category: str,
+        extended_stats: bool = False,
+        apply_settings: bool = False,
+        do_trim_now: bool = False,
+        settings_json: str = "",
+    ):
+        _ = (extended_stats, apply_settings, do_trim_now, settings_json)
         result = audit_items(items, workflow_json, default_category)
         return (
             result["json"],

--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -4,3 +4,4 @@
 | --- | --- | --- | --- | --- |
 | 2024-05-03-ops-ui | Expose per-mode presets for Arena AutoCache Ops to speed up common automation flows | AutoCache | 0.6 | proposed |
 | 2024-05-03-benchmark-cli | Add a CLI wrapper around the Ops benchmarking logic for headless cache health checks | Tooling | 0.5 | proposed |
+| 2024-05-04-audit-extended | Implement extended stats computation and settings overrides within the AutoCache Audit node | AutoCache | 0.4 | proposed |


### PR DESCRIPTION
Summary
- Подготовил узел аудита к приёму расширенных аргументов без изменения текущего поведения.

Changes
- Добавил опциональные параметры extended_stats, apply_settings, do_trim_now и settings_json к методу run узла ArenaAutoCacheAudit.
- Зафиксировал временную заглушку, исключающую предупреждения до будущей реализации логики.
- Обновил список идей с предложением по реализации расширенной обработки в аудите.

Docs
- docs/IDEAS.md (ru)

Changelog
- CHANGELOG.md ([Unreleased] → Changed)

Test Plan
- pytest tests/test_autocache_audit_warmup.py

Risks
- Низкие: новая сигнатура пока не задействует дополнительную логику.

Rollback
- git revert 7813d5b

Ideas
- Добавлена идея 2024-05-04-audit-extended в docs/IDEAS.md.


------
https://chatgpt.com/codex/tasks/task_b_68cf01299fe083248960d23a783a06c0