### PR TITLE
fix: обновлены режимы Arena AutoCache Ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Arena AutoCache dashboard and ops nodes with mode selection, benchmarking toggles, and dedicated smoke tests.
 - Extend the Arena AutoCache Audit node with optional `summary_json` output, runtime overrides, and multi-category extended stats plus trim execution feedback.
 ### Changed
+- Expose Arena AutoCache Ops mode selection as a validated dropdown and document the available options.
 - Prepare the AutoCache Audit node to accept extended stats and settings override arguments without altering current behaviour.
 - Extend Arena AutoCache index metadata to expose byte totals and the last HIT/MISS/TRIM/COPY event.
 - Prefix Arena AutoCache and legacy tiles node display names with the 🅰️ marker for consistent UI grouping.

--- a/custom_nodes/ComfyUI_Arena/README.md
+++ b/custom_nodes/ComfyUI_Arena/README.md
@@ -91,15 +91,14 @@ The dashboard node fuses stats and audit into one observability surface. Its `su
 
 **RU**
 
-Операционный узел объединяет прогрев (`Warmup`) и очистку (`Trim`). Установите `do_warmup=true`, чтобы копировать после аудита — это рекомендуемый сценарий `audit_then_warmup`. Добавьте `do_trim=true`, когда нужно освободить место в той же связке. `summary_json` отражает блоки `warmup_meta` и `trim` для UI.
+Операционный узел объединяет прогрев (`Warmup`) и очистку (`Trim`). Выберите режим `audit_then_warmup`, чтобы выполнить аудит и затем прогреть кэш — это рекомендуемый сценарий. Режим `audit` запускает только аудит, `warmup` — только прогрев, а `trim` — только очистку. `summary_json` отражает блоки `warmup_meta` и `trim` для UI.
 
 - **Входы**
   - `category` (`STRING`, по умолчанию `"checkpoints"`).
   - `items` (`STRING`, многострочный) — общая спецификация Audit/Warmup.
   - `workflow_json` (`STRING`, многострочный) — автодобавление моделей из workflow.
   - `default_category` (`STRING`, по умолчанию `"checkpoints"`).
-  - `do_warmup` (`BOOLEAN`, по умолчанию `false`).
-  - `do_trim` (`BOOLEAN`, по умолчанию `false`).
+  - `mode` (`STRING`, по умолчанию `"audit_then_warmup"`) — варианты: `audit_then_warmup`, `audit`, `warmup`, `trim`.
 - **Выходы**
   - `STRING` (`summary_json`) — объединённая сводка статуса и операций.
   - `STRING` (`warmup_json`) — отчёт прогрева.
@@ -107,15 +106,14 @@ The dashboard node fuses stats and audit into one observability surface. Its `su
 
 **EN**
 
-The Ops node coordinates warmups and trims. Toggle `do_warmup` to run copy jobs right after auditing — this is the recommended `audit_then_warmup` workflow. Enable `do_trim` when you want to reclaim space in the same pass. The resulting `summary_json` adds `warmup_meta` and `trim` blocks for dashboards.
+The Ops node coordinates warmups and trims. Pick the `audit_then_warmup` mode to run an audit followed by a warmup — this is the recommended workflow. Use `audit` for audit-only passes, `warmup` when you just need to fill the cache, and `trim` for cleanup-only operations. The resulting `summary_json` adds `warmup_meta` and `trim` blocks for dashboards.
 
 - **Inputs**
   - `category` (`STRING`, default `"checkpoints"`).
   - `items` (`STRING`, multiline) — same spec as Audit/Warmup.
   - `workflow_json` (`STRING`, multiline) — adds workflow-discovered models.
   - `default_category` (`STRING`, default `"checkpoints"`).
-  - `do_warmup` (`BOOLEAN`, default `false`).
-  - `do_trim` (`BOOLEAN`, default `false`).
+  - `mode` (`STRING`, default `"audit_then_warmup"`) — choices: `audit_then_warmup`, `audit`, `warmup`, `trim`.
 - **Outputs**
   - `STRING` (`summary_json`) — consolidated status + operations report.
   - `STRING` (`warmup_json`) — warmup report payload.
@@ -125,7 +123,7 @@ The Ops node coordinates warmups and trims. Toggle `do_warmup` to run copy jobs 
 
 1. Подайте один и тот же список `items` в Dashboard и Ops. / Feed the same `items` list into both Dashboard and Ops.
 2. Оцените `audit_meta.missing` в `summary_json` Dashboard. / Inspect `audit_meta.missing` in the Dashboard summary.
-3. Включите `do_warmup=true` (и при необходимости `do_trim=true`). / Flip `do_warmup=true` (and `do_trim=true` if needed).
+3. Переключите `mode` в `audit_then_warmup` (и выберите `trim`, если нужна только очистка). / Switch `mode` to `audit_then_warmup` (pick `trim` when you only need cleanup).
 4. Передайте `warmup_json` и `trim_json` в текстовые виджеты или логгеры. / Pipe `warmup_json` and `trim_json` to text widgets or loggers.
 
 **Бенчмаркинг / Benchmarking tips**

--- a/custom_nodes/ComfyUI_Arena/autocache/arena_auto_cache.py
+++ b/custom_nodes/ComfyUI_Arena/autocache/arena_auto_cache.py
@@ -45,6 +45,7 @@ I18N: dict[str, dict[str, str]] = {
         "input.do_trim": "Trim category after applying config",
         "input.do_warmup": "Warmup cache for listed items",
         "input.mode": "Operation mode",
+        "input.mode.tooltip": "Select operation mode: audit_then_warmup, audit, warmup, or trim",
         "input.benchmark_samples": "Benchmark sample count",
         "input.benchmark_read_mb": "Benchmark read limit (MiB)",
         "input.do_trim_now": "Trim category immediately",
@@ -92,6 +93,7 @@ I18N: dict[str, dict[str, str]] = {
         "input.do_trim": "Очистить категорию после применения настроек",
         "input.do_warmup": "Прогреть кэш для перечисленных элементов",
         "input.mode": "Режим операции",
+        "input.mode.tooltip": "Выберите режим: audit_then_warmup, audit, warmup или trim",
         "input.benchmark_samples": "Количество файлов для замера скорости",
         "input.benchmark_read_mb": "Лимит чтения для бенчмарка (МиБ)",
         "input.do_trim_now": "Очистить категорию немедленно",
@@ -2449,9 +2451,10 @@ class ArenaAutoCacheOps:
                 "mode": (
                     "STRING",
                     {
-                        "default": "audit_then_warmup",
+                        "default": ARENA_OPS_MODES[0],
+                        "choices": ARENA_OPS_MODES,
                         "description": t("input.mode"),
-                        "tooltip": t("input.mode"),
+                        "tooltip": t("input.mode.tooltip"),
                     },
                 ),
             },
@@ -2503,7 +2506,9 @@ class ArenaAutoCacheOps:
         benchmark_samples: int = 0,
         benchmark_read_mb: float = 0.0,
     ):
-        normalized_mode = (mode or "audit_then_warmup").strip().lower()
+        normalized_mode = str(mode or ARENA_OPS_MODES[0]).strip().lower()
+        if normalized_mode not in ARENA_OPS_MODE_SET:
+            normalized_mode = ARENA_OPS_MODES[0]
         run_audit = normalized_mode in {"audit", "audit_then_warmup"}
         run_warmup = normalized_mode in {"warmup", "audit_then_warmup"}
         run_trim = normalized_mode == "trim"
@@ -2684,3 +2689,12 @@ NODE_DISPLAY_NAME_MAPPINGS.update(
         "ArenaAutoCacheManager": t("node.manager"),
     }
 )
+ARENA_OPS_MODES: tuple[str, ...] = (
+    "audit_then_warmup",
+    "audit",
+    "warmup",
+    "trim",
+)
+
+ARENA_OPS_MODE_SET = set(ARENA_OPS_MODES)
+

--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -7,3 +7,5 @@
 | 2024-05-04-audit-extended | Implement extended stats computation and settings overrides within the AutoCache Audit node | AutoCache | 0.4 | done |
 | 2024-05-06-audit-presets | Ship reusable UI presets for common audit flows (stats only, trim only, audit+config) | AutoCache | 0.3 | proposed |
 | 2024-05-06-summary-webhook | Allow summary_json payloads to be pushed to a webhook for external monitoring dashboards | Integrations | 0.5 | proposed |
+| 2024-05-10-ops-mode-tooltips | Surface per-mode explanations directly in the Ops node UI to guide new operators | AutoCache | 0.4 | proposed |
+| 2024-05-10-ops-mode-preset | Offer saved presets that preconfigure Ops node inputs for nightly trim or warmup-only runs | AutoCache | 0.5 | proposed |

--- a/tests/test_autocache_ops_modes.py
+++ b/tests/test_autocache_ops_modes.py
@@ -1,0 +1,244 @@
+"""Mode selection tests for the Arena AutoCache Ops node."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+MODULE_NAME = "custom_nodes.ComfyUI_Arena.autocache.arena_auto_cache"
+
+
+class ArenaAutoCacheOpsModeSelectionTest(unittest.TestCase):
+    """Verify that Ops mode choices execute the expected operations."""
+
+    def setUp(self) -> None:  # noqa: D401 - unittest hook description inherited
+        self.addCleanup(sys.modules.pop, MODULE_NAME, None)
+        self.addCleanup(sys.modules.pop, "folder_paths", None)
+        self.addCleanup(lambda: os.environ.pop("ARENA_CACHE_ROOT", None))
+        self.addCleanup(lambda: os.environ.pop("ARENA_CACHE_ENABLE", None))
+        self.addCleanup(lambda: os.environ.pop("ARENA_CACHE_VERBOSE", None))
+
+    def _prepare_module(self):
+        folder_paths = types.ModuleType("folder_paths")
+        folder_paths.get_folder_paths = lambda category: []  # type: ignore[attr-defined]
+        folder_paths.get_full_path = lambda category, name: name  # type: ignore[attr-defined]
+        sys.modules["folder_paths"] = folder_paths
+
+        cache_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(cache_dir.cleanup)
+        os.environ["ARENA_CACHE_ROOT"] = cache_dir.name
+        os.environ["ARENA_CACHE_ENABLE"] = "1"
+        os.environ["ARENA_CACHE_VERBOSE"] = "0"
+
+        sys.modules.pop(MODULE_NAME, None)
+        return importlib.import_module(MODULE_NAME)
+
+    def _patch_ops_dependencies(self, module, log):
+        stack = contextlib.ExitStack()
+        cache_root = module._settings.root.as_posix()
+
+        def audit_stub(items, workflow_json, default_category):
+            log.append(("audit", items, workflow_json, default_category))
+            payload = {
+                "ok": True,
+                "items": [],
+                "timings": {"duration_seconds": 0.1},
+            }
+            return {
+                "payload": payload,
+                "json": json.dumps(payload, ensure_ascii=False, indent=2),
+                "items": [],
+                "total": 1,
+                "cached": 1,
+                "missing": 0,
+                "timings": {"duration_seconds": 0.1},
+            }
+
+        def warmup_stub(items, workflow_json, default_category):
+            log.append(("warmup", items, workflow_json, default_category))
+            payload = {
+                "ok": True,
+                "note": "warmup-ok",
+                "counts": {
+                    "total": 2,
+                    "warmed": 2,
+                    "copied": 2,
+                    "missing": 0,
+                    "errors": 0,
+                },
+                "items": [],
+                "timings": {"duration_seconds": 0.2},
+            }
+            return {
+                "payload": payload,
+                "json": json.dumps(payload, ensure_ascii=False, indent=2),
+                "total": 2,
+                "warmed": 2,
+                "copied": 2,
+                "missing": 0,
+                "errors": 0,
+                "timings": {"duration_seconds": 0.2},
+            }
+
+        def trim_stub(category):
+            log.append(("trim", category))
+            return {
+                "payload": {
+                    "ok": True,
+                    "note": "trim-ok",
+                    "category": category,
+                    "timings": {"duration_seconds": 0.3},
+                }
+            }
+
+        def stats_stub(category):
+            log.append(("stats", category))
+            payload = {
+                "ok": True,
+                "items": [],
+                "total_bytes": 0,
+                "total_gb": 0.0,
+                "max_size_gb": 0,
+            }
+            return {
+                "payload": payload,
+                "items": 0,
+                "total_gb": 0.0,
+                "total_bytes": 0,
+                "max_size_gb": 0,
+                "cache_root": cache_root,
+                "session_hits": 0,
+                "session_misses": 0,
+                "session_trims": 0,
+            }
+
+        stack.enter_context(mock.patch.object(module, "audit_items", side_effect=audit_stub))
+        stack.enter_context(mock.patch.object(module, "warmup_items", side_effect=warmup_stub))
+        stack.enter_context(mock.patch.object(module, "trim_category", side_effect=trim_stub))
+        stack.enter_context(mock.patch.object(module, "collect_stats", side_effect=stats_stub))
+        stack.enter_context(
+            mock.patch.object(module, "_extract_benchmark_candidates", return_value=[])
+        )
+        stack.enter_context(
+            mock.patch.object(
+                module,
+                "_benchmark_cache_entries",
+                return_value={"requested_samples": 0, "read_samples": 0},
+            )
+        )
+        return stack
+
+    def test_default_mode_runs_audit_and_warmup(self) -> None:
+        module = self._prepare_module()
+        ops = module.ArenaAutoCacheOps()
+        log: list[tuple[object, ...]] = []
+
+        with self._patch_ops_dependencies(module, log):
+            summary_json, warm_json, trim_json = ops.run(
+                "checkpoints", "", "", "checkpoints", ""
+            )
+
+        actions = {entry[0] for entry in log}
+        self.assertIn("audit", actions)
+        self.assertIn("warmup", actions)
+        self.assertNotIn("trim", actions)
+
+        warm_payload = json.loads(warm_json)
+        self.assertEqual(warm_payload["note"], "warmup-ok")
+
+        trim_payload = json.loads(trim_json)
+        self.assertEqual(trim_payload["note"], "trim skipped")
+
+        summary = json.loads(summary_json)
+        self.assertIn("Mode: audit_then_warmup", summary["ui"]["details"])
+
+    def test_audit_only_mode_skips_warmup_and_trim(self) -> None:
+        module = self._prepare_module()
+        ops = module.ArenaAutoCacheOps()
+        log: list[tuple[object, ...]] = []
+
+        with self._patch_ops_dependencies(module, log):
+            summary_json, warm_json, trim_json = ops.run(
+                "checkpoints", "", "", "checkpoints", "audit"
+            )
+
+        actions = {entry[0] for entry in log}
+        self.assertIn("audit", actions)
+        self.assertNotIn("warmup", actions)
+        self.assertNotIn("trim", actions)
+
+        warm_payload = json.loads(warm_json)
+        self.assertEqual(warm_payload["note"], "warmup skipped")
+
+        trim_payload = json.loads(trim_json)
+        self.assertEqual(trim_payload["note"], "trim skipped")
+
+        summary = json.loads(summary_json)
+        self.assertIn("Mode: audit", summary["ui"]["details"])
+
+    def test_warmup_only_mode_skips_audit_and_trim(self) -> None:
+        module = self._prepare_module()
+        ops = module.ArenaAutoCacheOps()
+        log: list[tuple[object, ...]] = []
+
+        with self._patch_ops_dependencies(module, log):
+            summary_json, warm_json, trim_json = ops.run(
+                "checkpoints", "", "", "checkpoints", "warmup"
+            )
+
+        actions = {entry[0] for entry in log}
+        self.assertIn("warmup", actions)
+        self.assertNotIn("audit", actions)
+        self.assertNotIn("trim", actions)
+
+        warm_payload = json.loads(warm_json)
+        self.assertEqual(warm_payload["note"], "warmup-ok")
+
+        trim_payload = json.loads(trim_json)
+        self.assertEqual(trim_payload["note"], "trim skipped")
+
+        summary = json.loads(summary_json)
+        self.assertIn("Mode: warmup", summary["ui"]["details"])
+
+    def test_trim_mode_runs_only_trim(self) -> None:
+        module = self._prepare_module()
+        ops = module.ArenaAutoCacheOps()
+        log: list[tuple[object, ...]] = []
+
+        with self._patch_ops_dependencies(module, log):
+            summary_json, warm_json, trim_json = ops.run(
+                "checkpoints", "", "", "checkpoints", "trim"
+            )
+
+        actions = {entry[0] for entry in log}
+        self.assertIn("trim", actions)
+        self.assertNotIn("audit", actions)
+        self.assertNotIn("warmup", actions)
+
+        warm_payload = json.loads(warm_json)
+        self.assertEqual(warm_payload["note"], "warmup skipped")
+
+        trim_payload = json.loads(trim_json)
+        self.assertEqual(trim_payload["note"], "trim-ok")
+
+        summary = json.loads(summary_json)
+        self.assertIn("Mode: trim", summary["ui"]["details"])
+
+
+if __name__ == "__main__":  # pragma: no cover - unittest main hook
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- перевёл поле режима узла Ops на выпадающий список с проверкой значения и резервным сценарием
- обновил подсказки и документацию, чтобы явно перечислять поддерживаемые режимы
- добавил юнит-тесты, покрывающие значение по умолчанию и каждую ветку выполнения узла

## Changes
- custom_nodes/ComfyUI_Arena/autocache/arena_auto_cache.py
- custom_nodes/ComfyUI_Arena/README.md
- tests/test_autocache_ops_modes.py
- docs/IDEAS.md
- CHANGELOG.md

## Docs
- custom_nodes/ComfyUI_Arena/README.md (ru/en)

## Changelog
- CHANGELOG.md ([Unreleased] → Changed)

## Test Plan
- pytest

## Risks
- Низкие: изменение UI ввода и проверка значения

## Rollback
- git revert d607fd50dc973949f7f04536684496a02f2519f9

## Ideas
- Идеи 2024-05-10-ops-mode-tooltips и 2024-05-10-ops-mode-preset добавлены в docs/IDEAS.md

------
https://chatgpt.com/codex/tasks/task_b_68cf78a52d108324ad15943900746325