### PR TITLE
test: добавлена проверка структуры UI payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add regression tests covering Arena AutoCache audit and warmup flows.
 - Add Arena AutoCache dashboard and ops nodes with mode selection, benchmarking toggles, and dedicated smoke tests.
 - Extend the Arena AutoCache Audit node with optional `summary_json` output, runtime overrides, and multi-category extended stats plus trim execution feedback.
+- Add a snapshot-backed test to lock the Arena AutoCache summary/warmup/trim JSON payload structure.
 ### Changed
 - Expose Arena AutoCache Ops mode selection as a validated dropdown and document the available options.
 - Prepare the AutoCache Audit node to accept extended stats and settings override arguments without altering current behaviour.

--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -13,3 +13,5 @@
 | 2024-05-12-overlay-settings | Expose overlay color and threshold tuning in a dedicated settings panel | UX | 0.5 | proposed |
 | 2024-05-13-overlay-toggle | Offer a per-node hotkey or checkbox to temporarily hide the AutoCache overlay during graph editing | UX | 0.3 | proposed |
 | 2024-05-13-overlay-export | Provide a small export panel that copies the latest summary and progress metrics from the overlay to the clipboard | Tooling | 0.4 | proposed |
+| 2024-05-15-ui-schema-validator | Ship a lightweight CLI that diffs stored AutoCache payload schemas to catch breaking changes early | Testing | 0.4 | proposed |
+| 2024-05-15-ui-payload-examples | Publish curated summary_json/warmup_json/trim_json samples in the docs for integrators | Docs | 0.3 | proposed |

--- a/tests/fixtures/arena_ui_payload_shape.json
+++ b/tests/fixtures/arena_ui_payload_shape.json
@@ -1,0 +1,174 @@
+{
+  "summary_json": {
+    "audit": {
+      "counts": {
+        "cached": "<int>",
+        "missing": "<int>",
+        "total": "<int>"
+      },
+      "enable": "<bool>",
+      "items": [
+        {
+          "cache_exists": "<bool>",
+          "cache_path": "<str>",
+          "category": "<str>",
+          "name": "<str>",
+          "source_path": "<str>",
+          "status": "<str>"
+        }
+      ],
+      "ok": "<bool>",
+      "timings": {
+        "duration_seconds": "<float>"
+      },
+      "ui": {
+        "details": [
+          "<str>",
+          "<str>"
+        ],
+        "headline": "<str>"
+      }
+    },
+    "audit_meta": {
+      "cached": "<int>",
+      "missing": "<int>",
+      "total": "<int>"
+    },
+    "ok": "<bool>",
+    "stats": {
+      "cache_root": "<str>",
+      "category": "<str>",
+      "enabled": "<bool>",
+      "items": "<int>",
+      "last_op": "<str>",
+      "last_path": "<str>",
+      "max_size_gb": "<int>",
+      "total_bytes": "<int>",
+      "total_gb": "<float>"
+    },
+    "stats_meta": {
+      "cache_root": "<str>",
+      "items": "<int>",
+      "session": {
+        "hits": "<int>",
+        "misses": "<int>",
+        "trims": "<int>"
+      },
+      "total_gb": "<float>"
+    },
+    "timestamp": "<float>",
+    "timings": {
+      "audit": {
+        "duration_seconds": "<float>"
+      },
+      "stats": {
+        "seconds": "<float>"
+      },
+      "warmup": {
+        "duration_seconds": "<float>"
+      }
+    },
+    "trim": {
+      "category": "<str>",
+      "items": "<int>",
+      "max_size_gb": "<int>",
+      "note": "<str>",
+      "ok": "<bool>",
+      "total_bytes": "<int>",
+      "total_gb": "<float>",
+      "trimmed": []
+    },
+    "ui": {
+      "details": [
+        "<str>",
+        "<str>",
+        "<str>",
+        "<str>"
+      ],
+      "headline": "<str>"
+    },
+    "warmup": {
+      "counts": {
+        "copied": "<int>",
+        "errors": "<int>",
+        "missing": "<int>",
+        "total": "<int>",
+        "warmed": "<int>"
+      },
+      "enable": "<bool>",
+      "items": [
+        {
+          "cache_exists": "<bool>",
+          "cache_path": "<str>",
+          "category": "<str>",
+          "name": "<str>",
+          "resolved_path": "<str>",
+          "status": "<str>"
+        }
+      ],
+      "ok": "<bool>",
+      "timings": {
+        "duration_seconds": "<float>"
+      },
+      "ui": {
+        "details": [
+          "<str>",
+          "<str>",
+          "<str>",
+          "<str>"
+        ],
+        "headline": "<str>"
+      }
+    },
+    "warmup_meta": {
+      "copied": "<int>",
+      "errors": "<int>",
+      "missing": "<int>",
+      "total": "<int>",
+      "warmed": "<int>"
+    }
+  },
+  "warmup_json": {
+    "counts": {
+      "copied": "<int>",
+      "errors": "<int>",
+      "missing": "<int>",
+      "total": "<int>",
+      "warmed": "<int>"
+    },
+    "enable": "<bool>",
+    "items": [
+      {
+        "cache_exists": "<bool>",
+        "cache_path": "<str>",
+        "category": "<str>",
+        "name": "<str>",
+        "resolved_path": "<str>",
+        "status": "<str>"
+      }
+    ],
+    "ok": "<bool>",
+    "timings": {
+      "duration_seconds": "<float>"
+    },
+    "ui": {
+      "details": [
+        "<str>",
+        "<str>",
+        "<str>",
+        "<str>"
+      ],
+      "headline": "<str>"
+    }
+  },
+  "trim_json": {
+    "category": "<str>",
+    "items": "<int>",
+    "max_size_gb": "<int>",
+    "note": "<str>",
+    "ok": "<bool>",
+    "total_bytes": "<int>",
+    "total_gb": "<float>",
+    "trimmed": []
+  }
+}

--- a/tests/test_arena_ui_payload.py
+++ b/tests/test_arena_ui_payload.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+MODULE_NAME = "custom_nodes.ComfyUI_Arena.autocache.arena_auto_cache"
+FIXTURE_PATH = Path(__file__).resolve().parent / "fixtures" / "arena_ui_payload_shape.json"
+
+
+def _to_shape(value: object) -> object:
+    if isinstance(value, dict):
+        return {key: _to_shape(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        return [_to_shape(item) for item in value]
+    if isinstance(value, bool):
+        return "<bool>"
+    if isinstance(value, int):
+        return "<int>"
+    if isinstance(value, float):
+        return "<float>"
+    if isinstance(value, str):
+        return "<str>"
+    if value is None:
+        return "<null>"
+    return f"<{type(value).__name__}>"
+
+
+@pytest.fixture
+def arena_ops_module(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> types.ModuleType:
+    source_dir = tmp_path / "source"
+    cache_dir = tmp_path / "cache"
+    source_dir.mkdir()
+    cache_dir.mkdir()
+    (source_dir / "model.safetensors").write_text("payload", encoding="utf-8")
+
+    folder_paths = types.ModuleType("folder_paths")
+
+    def _get_folder_paths(category: str):
+        if category in {"checkpoints", "loras"}:
+            return [str(source_dir)]
+        return []
+
+    def _get_full_path(category: str, name: str):
+        candidate = source_dir / name
+        return str(candidate) if candidate.exists() else None
+
+    folder_paths.get_folder_paths = _get_folder_paths  # type: ignore[attr-defined]
+    folder_paths.get_full_path = _get_full_path  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "folder_paths", folder_paths)
+    monkeypatch.setenv("ARENA_CACHE_ROOT", str(cache_dir))
+    monkeypatch.setenv("ARENA_CACHE_ENABLE", "1")
+    monkeypatch.setenv("ARENA_CACHE_VERBOSE", "0")
+
+    sys.modules.pop(MODULE_NAME, None)
+    module = importlib.import_module(MODULE_NAME)
+    module._STALE_LOCK_SECONDS = 0.01
+
+    yield module
+
+    sys.modules.pop(MODULE_NAME, None)
+
+
+def test_arena_ui_payload_matches_shape_snapshot(
+    arena_ops_module: types.ModuleType,
+) -> None:
+    expected_shape = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+    ops_node = arena_ops_module.ArenaAutoCacheOps()
+    summary_json, warmup_json, trim_json = ops_node.run(
+        "checkpoints",
+        "checkpoints:model.safetensors",
+        "",
+        "checkpoints",
+        "audit_then_warmup",
+    )
+
+    actual_shape = {
+        "summary_json": _to_shape(json.loads(summary_json)),
+        "warmup_json": _to_shape(json.loads(warmup_json)),
+        "trim_json": _to_shape(json.loads(trim_json)),
+    }
+
+    assert actual_shape == expected_shape


### PR DESCRIPTION
## Summary
- добавлен pytest-тест, который генерирует summary_json/warmup_json/trim_json и сверяет их форму со снапшотом
- зафиксирована форма ожидаемых UI-полей в JSON через отдельную фикстуру

## Changes
- создан снапшот-фикстура для структуры JSON-полей Arena AutoCache
- реализован pytest-тест, формирующий актуальную структуру и сравнивающий её со снапшотом
- обновлены идеи с предложениями по дальнейшей автоматизации проверки payload и примеров для документации

## Docs
- docs/IDEAS.md (en)

## Changelog
- [Unreleased] запись о добавлении снапшот-теста для UI payload

## Test Plan
- `pytest`

## Risks
- минимальные: тест чувствителен к осознанным изменениям структуры payload

## Rollback
- `git revert <commit>`

## Ideas
- добавлены идеи 2024-05-15-ui-schema-validator и 2024-05-15-ui-payload-examples в docs/IDEAS.md

------
https://chatgpt.com/codex/tasks/task_b_68cf848621708324ad29db86b1eae8f3