### PR TITLE
fix: сброшена подсветка оверлея AutoCache при очистке

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,3 +53,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restore package-level exports so ComfyUI can import `comfyui-arena-suite` from `custom_nodes`.
 - Keep cache helpers importable and return stub responses when the cache is disabled.
 - Avoid recording cache hits when `.copying` locks disappear but the cached file is missing by falling back to the source path.
+- Reset the AutoCache overlay palette and messages when node outputs are cleared so idle nodes no longer show stale highlights.

--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -15,3 +15,4 @@
 | 2024-05-13-overlay-export | Provide a small export panel that copies the latest summary and progress metrics from the overlay to the clipboard | Tooling | 0.4 | proposed |
 | 2024-05-15-ui-schema-validator | Ship a lightweight CLI that diffs stored AutoCache payload schemas to catch breaking changes early | Testing | 0.4 | proposed |
 | 2024-05-15-ui-payload-examples | Publish curated summary_json/warmup_json/trim_json samples in the docs for integrators | Docs | 0.3 | proposed |
+| 2024-05-16-overlay-idle-animation | Add a subtle fade transition when the AutoCache overlay returns to the idle palette to emphasize recovery | UX | 0.2 | proposed |

--- a/web/extensions/arena_autocache.js
+++ b/web/extensions/arena_autocache.js
@@ -544,10 +544,13 @@
         continue;
       }
       state.issues[field] = null;
-      if (parsed.data !== null) {
-        state[field] = parsed.data;
+      if (parsed.data === null) {
+        state[field] = null;
         dirty = true;
+        continue;
       }
+      state[field] = parsed.data;
+      dirty = true;
     }
 
     if (dirty) {


### PR DESCRIPTION
Summary
- Обновлена обработка пустых выводов AutoCache-узлов, чтобы оверлей принудительно пересобирался и сбрасывал палитру.

Changes
- Настроена логика `updateNodeFromOutputs`, чтобы очищать состояние и перезапускать построение отображения при `null`-payload.
- Обновлён CHANGELOG и зафиксирована новая UX-идея по плавному возврату оверлея к idle-состоянию.

Docs
- docs/IDEAS.md (ru)

Changelog
- Добавлена запись в [Unreleased] → Fixed.

Test Plan
- pytest
- Manual (локально): выполнить AutoCache-узел, затем очистить/перезагрузить граф в ComfyUI и убедиться, что подсветка рамки и подсказки исчезают.

Risks
- Минимальный: изменение затрагивает только клиентский оверлей AutoCache.

Rollback
- Revert коммит `fix: сброшена подсветка оверлея при очистке AutoCache`.

Ideas
- Добавлена идея #2024-05-16-overlay-idle-animation в docs/IDEAS.md.


------
https://chatgpt.com/codex/tasks/task_b_68cf8cb432d08324841d7977a3fb6882