### PR TITLE
fix: сохранение переменных окружения после arena_set_cache.bat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Dashboard/Ops coverage with compatibility table, status-line examples, and benchmarking guidance in the AutoCache README.
 - Document the new dashboard/ops nodes and timing fields in the bilingual node references.
 ### Fixed
+- Ensure `arena_set_cache.bat` leaves `ARENA_CACHE_*` variables available in the parent CMD session for subsequent launches.
 - Point AutoCache web assets discovery at the repository-level `web` directory so the overlay loads without manual symlinks.
 - Aggregate Arena node and display mapping exports at the package root so ComfyUI can discover nodes even when optional submodules fail to import.
 - Allow cache lookups to fall back to source files when `.copying` locks persist and clean up stale locks before retrying copies.

--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -17,3 +17,4 @@
 | 2024-05-15-ui-payload-examples | Publish curated summary_json/warmup_json/trim_json samples in the docs for integrators | Docs | 0.3 | proposed |
 | 2024-05-16-overlay-idle-animation | Add a subtle fade transition when the AutoCache overlay returns to the idle palette to emphasize recovery | UX | 0.2 | proposed |
 | 2024-05-18-web-assets-check | Add an integration check that ensures the Arena web overlay assets are discoverable after installation | Testing | 0.3 | proposed |
+| 2024-05-20-cache-env-ui | Provide a tiny Windows tray helper that toggles ARENA_CACHE_* variables and updates the current session | Tooling | 0.3 | proposed |

--- a/scripts/arena_set_cache.bat
+++ b/scripts/arena_set_cache.bat
@@ -1,0 +1,58 @@
+@echo off
+set "SCRIPT_NAME=%~nx0"
+
+if "%~1"=="/h" goto :help
+if "%~1"=="-h" goto :help
+if "%~1"=="/?" goto :help
+
+set "CACHE_ROOT=%~1"
+if not defined CACHE_ROOT (
+    if defined ARENA_CACHE_ROOT (
+        set "CACHE_ROOT=%ARENA_CACHE_ROOT%"
+    ) else if defined LOCALAPPDATA (
+        set "CACHE_ROOT=%LOCALAPPDATA%\ArenaAutoCache"
+    ) else (
+        for %%I in ("%~dp0..\ArenaAutoCache") do set "CACHE_ROOT=%%~fI"
+    )
+)
+
+for %%I in ("%CACHE_ROOT%") do set "CACHE_ROOT=%%~fI"
+set "ARENA_CACHE_ROOT=%CACHE_ROOT%"
+
+if "%~2"=="" (
+    if not defined ARENA_CACHE_ENABLE set "ARENA_CACHE_ENABLE=1"
+) else (
+    set "ARENA_CACHE_ENABLE=%~2"
+)
+
+if "%~3"=="" (
+    if not defined ARENA_CACHE_VERBOSE set "ARENA_CACHE_VERBOSE=0"
+) else (
+    set "ARENA_CACHE_VERBOSE=%~3"
+)
+
+echo.
+echo [Arena AutoCache]
+echo   ARENA_CACHE_ROOT=%ARENA_CACHE_ROOT%
+if defined ARENA_CACHE_ENABLE echo   ARENA_CACHE_ENABLE=%ARENA_CACHE_ENABLE%
+if defined ARENA_CACHE_VERBOSE echo   ARENA_CACHE_VERBOSE=%ARENA_CACHE_VERBOSE%
+echo.
+echo Use "call %SCRIPT_NAME% <cache_dir> [enable] [verbose]" from CMD to persist variables.
+
+goto :eof
+
+:help
+echo Sets Arena AutoCache environment variables in the current CMD session.
+echo.
+echo Usage:
+echo   call %SCRIPT_NAME% ^<cache_dir^> [enable] [verbose]
+echo.
+echo Examples:
+echo   call %SCRIPT_NAME% D:\ComfyCache
+
+echo Notes:
+echo   - Invoke with CALL so the parent shell captures variables.
+echo   - The default path falls back to %%LOCALAPPDATA%%\ArenaAutoCache if no argument is provided.
+echo   - Existing ARENA_CACHE_* variables remain untouched unless new values are supplied.
+
+goto :eof


### PR DESCRIPTION
Summary
- Обновил скрипт `arena_set_cache.bat`, чтобы переменные `ARENA_CACHE_*` оставались в текущем окне CMD после выполнения.
- Расширил вывод справки и подсказки по умолчанию, упростив выбор директории кэша и значений переключателей.

Changes
- Добавил новый вариант `scripts/arena_set_cache.bat` без `setlocal`, с нормализацией путей и настройкой `ARENA_CACHE_ROOT/ENABLE/VERBOSE`.
- Задокументировал исправление в `[Unreleased]` секции CHANGELOG.
- Зафиксировал новую идею про трей-хелпер для переменных окружения в `docs/IDEAS.md`.

Docs
- docs/IDEAS.md (ru)

Changelog
- [Unreleased] Fixed — Ensure `arena_set_cache.bat` leaves `ARENA_CACHE_*` variables available in the parent CMD session for subsequent launches.

Test Plan
- pytest

Risks
- Неверная нормализация путей может задать некорректный `ARENA_CACHE_ROOT` при запуске вне репозитория.

Rollback
- `git revert 289880e` и удалить новую запись в CHANGELOG/IDEAS.

Ideas
- Добавлена идея `2024-05-20-cache-env-ui` в docs/IDEAS.md.


------
https://chatgpt.com/codex/tasks/task_b_68cf939d4c08832481a15f5c0f530a31