### PR TITLE
fix: корректная экранизация setx в bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Normalize AutoCache overlay output aliases so localized socket names update the summary, warmup, and trim panels consistently.
+- Escape trailing backslashes when persisting Windows cache variables so `setx` handles quoted paths without errors.
 - Ensure `arena_set_cache.bat` leaves `ARENA_CACHE_*` variables available in the parent CMD session for subsequent launches.
 - Trigger the Arena cache folder picker when no path is supplied and quote the PowerShell command so the selection populates `CACHE_ROOT` correctly.
 - Point AutoCache web assets discovery at the repository-level `web` directory so the overlay loads without manual symlinks.

--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -23,3 +23,4 @@
 | 2024-05-21-cache-selector-cli | Offer a cross-platform CLI prompt for selecting the Arena cache directory when Windows dialogs are unavailable | Tooling | 0.2 | proposed |
 | 2024-05-22-bootstrap-healthcheck | Add a smoke test script that validates persisted ARENA_CACHE_* variables and disk free space after running the bootstrap | Tooling | 0.3 | proposed |
 | 2024-05-22-bootstrap-gui | Build a small WinUI front-end for managing Arena cache limits and toggles beyond the initial bootstrap | UX | 0.4 | proposed |
+| 2024-05-23-bootstrap-escape-check | Add automated validation that cache paths ending with backslashes are safely escaped before persistence | Tooling | 0.2 | proposed |

--- a/scripts/arena_bootstrap_cache.bat
+++ b/scripts/arena_bootstrap_cache.bat
@@ -136,12 +136,17 @@ exit /b 0
 set "VAR_NAME=%~1"
 set "VAR_VALUE=%~2"
 if not defined VAR_NAME exit /b 0
-setx "%VAR_NAME%" "%VAR_VALUE%" >nul
+set "VAR_ESCAPED=%VAR_VALUE%"
+if defined VAR_ESCAPED (
+    if "%VAR_ESCAPED:~-1%"=="\" set "VAR_ESCAPED=%VAR_ESCAPED%\"
+)
+setx "%VAR_NAME%" "%VAR_ESCAPED%" >nul
 if errorlevel 1 (
     echo Failed to persist %VAR_NAME% with SETX.
 ) else (
     set "PERSIST_SUCCESS=1"
 )
+if defined VAR_NAME set "%VAR_NAME%=%VAR_VALUE%"
 exit /b 0
 
 :help


### PR DESCRIPTION
## Summary
- Обновлён Windows bootstrap, чтобы корректно обрабатывать пути к кешу с завершающим обратным слэшем.
- Сохранено исходное значение переменной в текущей сессии, избегая двойного экранирования.

## Changes
- Добавлено двойное экранирование завершающего слэша перед вызовом `setx` и восстановление исходного значения переменной.
- Обновлён журнал изменений с описанием фикса.
- Задокументирована идея автоматической проверки экранирования в `docs/IDEAS.md`.

## Docs
- CHANGELOG.md (ru)
- docs/IDEAS.md

## Changelog
- [Unreleased] — Fixed: Escape trailing backslashes when persisting Windows cache variables so `setx` handles quoted paths without errors.

## Test Plan
- Невозможно выполнить в текущем окружении (требуется Windows/`setx`); проверка проведена анализом логики.

## Risks
- Низкие: изменения затрагивают только Windows-скрипт при сохранении переменных.

## Rollback
- Revert двух последних коммитов `fix: исправлено экранирование cache bootstrap` и `docs: обновлен changelog для cache bootstrap`.

## Ideas
- Добавлена идея `2024-05-23-bootstrap-escape-check` в `docs/IDEAS.md`.


------
https://chatgpt.com/codex/tasks/task_b_68cfa545cd8c832485cd4f0254587ccc