### PR TITLE
fix: предзаполняем оверлей autocache в idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set the legacy tiles segmentation node category to `Arena/Tiles` for improved UI grouping.
 - Enrich audit and warmup payloads with `ui`/`timings` metadata and extend ops execution to cover audit, warmup, and trim modes.
 - Record audit summaries with explicit action feedback so UI widgets can confirm applied settings and trims.
+- Prefill Arena AutoCache overlay state on node creation so idle nodes render their headline and palette without waiting for outputs.
 ### Docs
 - Document the auto-discovery path and DevTools verification flow for the Arena web overlay in the README, RU/EN guides, and node reference. / **RU:** Задокументирован путь автообнаружения и проверка через DevTools для веб-оверлея Arena в README, русских/английских гайдах и справочнике узлов.
 - Document the AutoCache web overlay behaviour and coverage in the bilingual node reference.

--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -30,3 +30,4 @@
 | 2024-05-25-legacy-shim | Provide lightweight shim nodes that explain legacy dependencies when the module is missing | UX | 0.2 | proposed |
 | 2024-05-26-overlay-devtools-hint | Add an overlay tooltip or help link that reminds operators how to verify asset loading via DevTools | UX | 0.2 | proposed |
 | 2024-05-26-overlay-console-bundle | Emit a startup console summary of overlay discovery and any asset load errors for quicker troubleshooting | Reliability | 0.3 | proposed |
+| 2024-05-27-overlay-idle-prefill | Provide configurable defaults for idle overlay messaging to highlight node mode or category context | UX | 0.3 | proposed |

--- a/web/extensions/arena_autocache.js
+++ b/web/extensions/arena_autocache.js
@@ -122,6 +122,16 @@
     return state;
   }
 
+  function rebuildDisplay(node, state) {
+    if (!node) {
+      return;
+    }
+    const currentState = state || ensureState(node);
+    currentState.display = buildDisplay(currentState);
+    applyPalette(node, currentState.display.severity);
+    scheduleDraw(node);
+  }
+
   function decorateNode(node) {
     if (!node || node.__arenaAutoCacheDecorated) {
       return;
@@ -667,9 +677,7 @@
     }
 
     if (dirty) {
-      state.display = buildDisplay(state);
-      applyPalette(node, state.display.severity);
-      scheduleDraw(node);
+      rebuildDisplay(node, state);
     }
   }
 
@@ -680,7 +688,8 @@
     for (const node of graphApp.graph._nodes) {
       if (isTargetNode(node)) {
         decorateNode(node);
-        ensureState(node);
+        const state = ensureState(node);
+        rebuildDisplay(node, state);
       }
     }
   }
@@ -699,7 +708,8 @@
         return;
       }
       decorateNode(node);
-      ensureState(node);
+      const state = ensureState(node);
+      rebuildDisplay(node, state);
     },
     onNodeOutputsUpdated(nodeOutputs) {
       if (!nodeOutputs || typeof nodeOutputs !== "object") {


### PR DESCRIPTION
Summary
- Предзаполнил состояние оверлея Arena AutoCache для существующих и новых нод сразу после декорации
- Обновил таблицу идей свежим предложением по улучшению idle-состояния оверлея

Changes
- Добавил переиспользуемый хелпер для пересборки отображения и повторно использовал его при создании/бутстрапе нод и при обновлении выходов
- Настроил первичную отрисовку оверлея и палитры для целевых нод без ожидания выполнения

Docs
- Обновлён `docs/IDEAS.md`

Changelog
- Добавлена запись в [Unreleased] о предзаполнении состояния оверлея при создании нод

Test Plan
- `pytest`

Risks
- Возможны редкие рассинхроны отрисовки, если граф ещё не готов к перерисовке в момент бутстрапа

Rollback
- `git revert <commit>`

Ideas
- 2024-05-27-overlay-idle-prefill (docs/IDEAS.md)


------
https://chatgpt.com/codex/tasks/task_b_68cfbca6ce14832482384e63759932b1