### PR TITLE
fix: скорректирован fallback веб-ресурсов

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduce `arena_bootstrap_cache.bat` to persist Arena AutoCache variables on Windows and prime the current session.
 - Add a WinForms bootstrap helper (`scripts/arena_bootstrap_cache.ps1`) for selecting the cache folder and limit on Windows.
 ### Changed
+- Update the Arena web directory fallback to prefer package-local assets for portable installs. / **RU:** Обновлён резервный путь веб-ресурсов Arena, теперь используется каталог рядом с пакетом для переносимых сборок.
 - Auto-detect the Arena AutoCache web overlay from `ComfyUI/custom_nodes/comfyui-arena-suite/web`, eliminating manual copy steps. / **RU:** Автоматически определяем веб-оверлей Arena AutoCache из `ComfyUI/custom_nodes/comfyui-arena-suite/web`, ручное копирование больше не требуется.
 - Register the Arena AutoCache web overlay as an ESM module while falling back to the legacy global `app` lookup and logging a clear status message. / **RU:** Регистрируем веб-оверлей Arena AutoCache как ESM-модуль с откатом к глобальному `app` и понятным сообщением о статусе загрузки.
 - Log legacy module import failures as warnings so the package loads without those nodes instead of aborting.

--- a/custom_nodes/ComfyUI_Arena/__init__.py
+++ b/custom_nodes/ComfyUI_Arena/__init__.py
@@ -22,7 +22,7 @@ def _resolve_web_directory() -> str:
         if (candidate / "extensions" / "arena_autocache.js").exists():
             return str(candidate)
     # RU: если нужный каталог не найден, вернём прежний путь рядом с пакетом
-    return str(arena_root.parent.parent / "web")
+    return str(arena_root.parent / "web")
 
 NODE_CLASS_MAPPINGS: dict[str, type] = {}
 NODE_DISPLAY_NAME_MAPPINGS: dict[str, str] = {}

--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -35,3 +35,4 @@
 | 2024-05-29-overlay-loader-telemetry | Capture overlay load path (ESM vs fallback) and expose it in a debug panel for quicker troubleshooting | Reliability | 0.2 | proposed |
 | 2024-06-01-overlay-event-monitor | Surface a debug widget listing active overlay event subscriptions and their sources | Reliability | 0.2 | proposed |
 | 2024-06-01-overlay-fallback-toggle | Expose a settings toggle to force-enable or disable the execution-event fallback for the overlay | UX | 0.2 | proposed |
+| 2024-06-02-web-fallback-selftest | Add a lightweight unit test that simulates missing global assets to confirm the package-local web fallback stays valid | Reliability | 0.2 | proposed |

--- a/tests/test_arena_web_directory.py
+++ b/tests/test_arena_web_directory.py
@@ -1,0 +1,23 @@
+"""Ensure the Arena web assets are resolved from the repository root."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def test_web_directory_points_to_repo_root() -> None:
+    """WEB_DIRECTORY should locate the shared web extension assets."""
+
+    module = importlib.import_module("custom_nodes.ComfyUI_Arena")
+    web_dir = Path(module.WEB_DIRECTORY)
+
+    expected = PROJECT_ROOT / "web"
+    assert web_dir.resolve() == expected.resolve()
+    assert (web_dir / "extensions" / "arena_autocache.js").exists()


### PR DESCRIPTION
## Summary
- скорректирован резервный путь веб-активов Arena, чтобы он ссылался на каталог рядом с пакетом
- добавлен тест, подтверждающий обнаружение корневых веб-ресурсов с `extensions/arena_autocache.js`

## Changes
- обновлён `_resolve_web_directory()` с новым fallback на `custom_nodes/ComfyUI_Arena/web`
- добавлен модульный тест проверки `WEB_DIRECTORY`
- зафиксирована новая идея по самопроверке fallback и обновлён changelog

## Docs
- docs/IDEAS.md (ru)

## Changelog
- CHANGELOG.md ([Unreleased])

## Test Plan
- `pytest`

## Risks
- минимальные: изменения затрагивают только путь к веб-ресурсам и тесты

## Rollback
- выполнить `git revert <commit>` и удалить добавленный тест

## Ideas
- 2024-06-02-web-fallback-selftest — добавлена в docs/IDEAS.md

------
https://chatgpt.com/codex/tasks/task_b_68cfd32b85448324ae3b706197f8d4d0