### PR TITLE
test: добавлены пропуски при отсутствии ассетов

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Overlay polling fallback: periodically reads node outputs (~500 ms) for Dashboard/Ops/Audit nodes to keep the UI in sync even when no frontend events are fired (Desktop compatibility).
 - Desktop execution store fallback: when `getOutputData()` returns nothing, the overlay now attempts to read outputs from the Desktop `executionStore` (supports Map/object containers and locator ids like `subgraph:localId`).
 - Subscribe to `api.executed` events (via `/scripts/api.js`) and update overlay directly from execution payloads; improves reliability across Desktop frontends.
+- Arena AutoCache overlay tests now skip when the web asset bundle is missing, preventing false negatives on minimal installations.
 
 ### Added
 - Declare setuptools metadata with explicit package listings and bundle docs/web assets into distributions so wheels ship the Arena overlay.

--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -39,3 +39,5 @@
 | 2024-06-05-packaging-metadata-tool | Provide a CLI helper that validates MANIFEST/pyproject consistency before release | Packaging | 0.3 | proposed |
 | 2024-06-05-build-cache-matrix | Cache `python -m build` artifacts in CI to speed up multi-version smoke checks | CI | 0.2 | proposed |
 | 2024-06-06-overlay-asset-selfheal | Provide an optional CLI fixer that downloads missing Arena web assets when the warning is detected | Reliability | 0.3 | proposed |
+| 2024-06-07-overlay-pytest-fixture | Provide a shared pytest plugin that validates Arena overlay assets before integration tests | Testing | 0.2 | proposed |
+| 2024-06-07-overlay-cache-backfill | Add a dev script that repopulates missing overlay assets from packaged wheels during setup | Tooling | 0.3 | proposed |


### PR DESCRIPTION
## Summary
- добавлен общий помощник в тестах, который ищет web/extensions/arena_autocache.js и при отсутствии ассета аккуратно пропускает проверку
- обеспечено использование проверки во всех сценариях запуска Node-скриптов, чтобы исключить ложные падения в минимальных установках

## Changes
- обновлён tests/test_arena_autocache_overlay.py с импортом pytest, вспомогательной функцией и вызовами в setUp
- расширен CHANGELOG.md записью о новом поведении тестов
- добавлены две идеи в docs/IDEAS.md

## Docs
- docs/IDEAS.md (ru)

## Changelog
- CHANGELOG.md ([Unreleased] → Fixed)

## Test Plan
- pytest tests/test_arena_autocache_overlay.py -q

## Risks
- минимальные: изменение затрагивает только условия запуска тестов и не влияет на рабочий код пакета

## Rollback
- git revert <commit>

## Ideas
- 2024-06-07-overlay-pytest-fixture (docs/IDEAS.md)
- 2024-06-07-overlay-cache-backfill (docs/IDEAS.md)


------
https://chatgpt.com/codex/tasks/task_b_68d02bfeba6483248d74d6e70c50fd70