### PR TITLE
fix: упорядочены константы режима ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enrich audit and warmup payloads with `ui`/`timings` metadata and extend ops execution to cover audit, warmup, and trim modes.
 - Record audit summaries with explicit action feedback so UI widgets can confirm applied settings and trims.
 - Prefill Arena AutoCache overlay state on node creation so idle nodes render their headline and palette without waiting for outputs.
+- Reorder Arena Ops mode constant declarations ahead of the node class definition to clarify initialization ordering.
 ### Docs
 - Document the auto-discovery path and DevTools verification flow for the Arena web overlay in the README, RU/EN guides, and node reference. / **RU:** Задокументирован путь автообнаружения и проверка через DevTools для веб-оверлея Arena в README, русских/английских гайдах и справочнике узлов.
 - Document the AutoCache web overlay behaviour and coverage in the bilingual node reference.

--- a/custom_nodes/ComfyUI_Arena/autocache/arena_auto_cache.py
+++ b/custom_nodes/ComfyUI_Arena/autocache/arena_auto_cache.py
@@ -2340,6 +2340,16 @@ class ArenaAutoCacheDashboard:
         return (summary_json, stats_result["json"], audit_result["json"])
 
 
+ARENA_OPS_MODES: tuple[str, ...] = (
+    "audit_then_warmup",
+    "audit",
+    "warmup",
+    "trim",
+)
+
+ARENA_OPS_MODE_SET = set(ARENA_OPS_MODES)
+
+
 class ArenaAutoCacheOps:
     """RU: Комбинированные операции прогрева и очистки с отчётом."""
 
@@ -2623,12 +2633,3 @@ NODE_DISPLAY_NAME_MAPPINGS.update(
         "ArenaAutoCacheManager": t("node.manager"),
     }
 )
-ARENA_OPS_MODES: tuple[str, ...] = (
-    "audit_then_warmup",
-    "audit",
-    "warmup",
-    "trim",
-)
-
-ARENA_OPS_MODE_SET = set(ARENA_OPS_MODES)
-

--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -43,3 +43,4 @@
 | 2024-06-07-overlay-cache-backfill | Add a dev script that repopulates missing overlay assets from packaged wheels during setup | Tooling | 0.3 | proposed |
 | 2024-06-08-locale-regression-suite | Extend localization tests to cover all Arena nodes across supported languages with snapshot assertions | Testing | 0.3 | proposed |
 | 2024-06-09-autocache-locale-addon | Explore optional community-driven language packs for Arena AutoCache nodes with external maintenance | AutoCache | 0.2 | proposed |
+| 2024-06-11-ops-mode-config-hints | Add inline docs explaining how to extend Arena Ops mode choices via config stubs for custom workflows | AutoCache | 0.3 | proposed |


### PR DESCRIPTION
## Summary
- перенесены объявления режимов Arena Ops к определению класса, чтобы исключить повторы и гарантировать их инициализацию до использования
- зафиксирована запись в changelog и добавлена новая идея по расширению режимов через конфиги

## Changes
- переставлены константы `ARENA_OPS_MODES` и `ARENA_OPS_MODE_SET` перед классом `ArenaAutoCacheOps`
- обновлён CHANGELOG с описанием перестановки констант
- пополнен список идей предложением по документированию расширения режимов

## Docs
- docs/IDEAS.md (ru)

## Changelog
- [Unreleased] — добавлена строка про перенос объявлений режимов Ops

## Test Plan
- `python -c "import custom_nodes.ComfyUI_Arena.autocache.arena_auto_cache"` — модуль импортируется без ошибок
- `pytest tests/test_autocache_ops_modes.py` — все проверки проходят
- `pytest tests/test_autocache_config.py tests/test_autocache_audit_warmup.py tests/test_autocache_warmup.py tests/test_arena_auto_cache.py` — смежные автокэш тесты проходят

## Risks
- минимальные: потенциальные конфликты при дальнейших правках соседних объявлений

## Rollback
- выполнить `git revert <commit>` и повторно прогнать тесты

## Ideas
- 2024-06-11-ops-mode-config-hints — зафиксирована в docs/IDEAS.md

------
https://chatgpt.com/codex/tasks/task_b_68d03f6766688324bf41b9fb82fa2016