### PR TITLE
fix: предотвращено дублирование preview bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Desktop execution store fallback: when `getOutputData()` returns nothing, the overlay now attempts to read outputs from the Desktop `executionStore` (supports Map/object containers and locator ids like `subgraph:localId`).
 - Subscribe to `api.executed` events (via `/scripts/api.js`) and update overlay directly from execution payloads; improves reliability across Desktop frontends.
 - Arena AutoCache overlay tests now skip when the web asset bundle is missing, preventing false negatives on minimal installations.
+- Legacy preview bridge now reuses cached identifiers for repeated node/file pairs so duplicate entries no longer accumulate.
 
 ### Added
 - Declare setuptools metadata with explicit package listings and bundle docs/web assets into distributions so wheels ship the Arena overlay.

--- a/custom_nodes/ComfyUI_Arena/legacy/core.py
+++ b/custom_nodes/ComfyUI_Arena/legacy/core.py
@@ -70,14 +70,16 @@ def is_execution_model_version_supported():
 def set_previewbridge_image(node_id, file, item):
     global pb_id_cnt
 
-    if file in preview_bridge_image_name_map:
-        pb_id = preview_bridge_image_name_map[node_id, file]
-        if pb_id.startswith(f"${node_id}"):
-            return pb_id
+    key = (node_id, file)
+
+    if key in preview_bridge_image_name_map:
+        cached_pb_id, cached_item = preview_bridge_image_name_map[key]
+        preview_bridge_image_id_map.setdefault(cached_pb_id, (file, cached_item))
+        return cached_pb_id
 
     pb_id = f"${node_id}-{pb_id_cnt}"
     preview_bridge_image_id_map[pb_id] = (file, item)
-    preview_bridge_image_name_map[node_id, file] = (pb_id, item)
+    preview_bridge_image_name_map[key] = (pb_id, item)
     pb_id_cnt += 1
 
     return pb_id

--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -44,3 +44,4 @@
 | 2024-06-08-locale-regression-suite | Extend localization tests to cover all Arena nodes across supported languages with snapshot assertions | Testing | 0.3 | proposed |
 | 2024-06-09-autocache-locale-addon | Explore optional community-driven language packs for Arena AutoCache nodes with external maintenance | AutoCache | 0.2 | proposed |
 | 2024-06-11-ops-mode-config-hints | Add inline docs explaining how to extend Arena Ops mode choices via config stubs for custom workflows | AutoCache | 0.3 | proposed |
+| 2024-06-12-preview-bridge-stats | Track preview bridge cache hits and reuse metrics for debugging duplication issues | Reliability | 0.2 | proposed |

--- a/tests/test_legacy_preview_bridge.py
+++ b/tests/test_legacy_preview_bridge.py
@@ -1,0 +1,106 @@
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+def _stub_module(name: str) -> ModuleType:
+    module = ModuleType(name)
+    sys.modules[name] = module
+    return module
+
+
+def _ensure_module(name: str) -> ModuleType:
+    if name in sys.modules:
+        return sys.modules[name]
+    if "." in name:
+        parent_name, _, child_name = name.rpartition(".")
+        parent = _ensure_module(parent_name)
+        module = ModuleType(name)
+        setattr(parent, child_name, module)
+        sys.modules[name] = module
+        return module
+    return _stub_module(name)
+
+
+for module_name in (
+    "numpy",
+    "torch",
+    "nodes",
+    "cv2",
+    "folder_paths",
+):
+    _ensure_module(module_name)
+
+
+segment_anything = _ensure_module("segment_anything")
+segment_anything.SamPredictor = SimpleNamespace
+latent_preview = _ensure_module("latent_preview")
+latent_preview.TAESD = SimpleNamespace
+latent_preview.TAESDPreviewerImpl = SimpleNamespace
+latent_preview.Latent2RGBPreviewer = SimpleNamespace
+
+
+comfy_extras = _ensure_module("comfy_extras")
+
+
+class _NoiseRandomNoise:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def generate_noise(self, *args, **kwargs):
+        return None
+
+
+_ensure_module("comfy_extras.nodes_custom_sampler").Noise_RandomNoise = _NoiseRandomNoise
+_ensure_module("comfy_extras.nodes_upscale_model")
+_ensure_module("comfy_extras.nodes_differential_diffusion")
+
+skimage_measure = _ensure_module("skimage.measure")
+skimage_measure.label = lambda *args, **kwargs: None
+
+server_module = _ensure_module("server")
+server_module.PromptServer = SimpleNamespace
+
+comfy_module = _ensure_module("comfy")
+ksampler = type("KSampler", (), {"SCHEDULERS": []})
+comfy_module.samplers = SimpleNamespace(KSampler=ksampler)
+model_management_module = _ensure_module("comfy.model_management")
+setattr(comfy_module, "model_management", model_management_module)
+cli_args_module = _ensure_module("comfy.cli_args")
+cli_args_module.args = SimpleNamespace(latent_preview_method=None)
+
+
+class _LatentPreviewMethod:
+    NoPreviews = "NoPreviews"
+    Auto = "Auto"
+    Latent2RGB = "Latent2RGB"
+    TAESD = "TAESD"
+
+
+cli_args_module.LatentPreviewMethod = _LatentPreviewMethod
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import custom_nodes.ComfyUI_Arena.legacy.core as legacy_core
+
+
+def test_set_previewbridge_image_reuses_cached_identifier(monkeypatch):
+    monkeypatch.setattr(legacy_core, "preview_bridge_image_name_map", {})
+    monkeypatch.setattr(legacy_core, "preview_bridge_image_id_map", {})
+    monkeypatch.setattr(legacy_core, "pb_id_cnt", 1)
+
+    first_item = object()
+    first_id = legacy_core.set_previewbridge_image("node123", "file.png", first_item)
+
+    second_item = object()
+    second_id = legacy_core.set_previewbridge_image("node123", "file.png", second_item)
+
+    assert first_id == second_id
+    assert legacy_core.preview_bridge_image_name_map == {
+        ("node123", "file.png"): (first_id, first_item)
+    }
+    assert legacy_core.preview_bridge_image_id_map == {first_id: ("file.png", first_item)}
+    assert legacy_core.pb_id_cnt == 2


### PR DESCRIPTION
## Summary
- Обновил кеш preview bridge, чтобы повторные обращения возвращали существующий идентификатор без роста счётчика.
- Расширил набор заглушек и написал тест, фиксирующий повторное использование идентификатора при одинаковых аргументах.

## Changes
- В `legacy/core.py` добавлена проверка ключа `(node_id, file)` и повторное использование кэшированной записи.
- Создан `tests/test_legacy_preview_bridge.py` с юнит-тестом, который вызывает функцию дважды и проверяет неизменность идентификатора и отсутствие дублей.
- Обновлены `CHANGELOG.md` и `docs/IDEAS.md`.

## Docs
- docs/IDEAS.md (ru)

## Changelog
- CHANGELOG.md дополнен пунктом о фиксе переиспользования идентификаторов preview bridge.

## Test Plan
- `pytest tests/test_legacy_preview_bridge.py`

## Risks
- Низкие: изменение затрагивает только кеширование идентификаторов и тестовый контур.

## Rollback
- `git revert <commit>` и удаление теста `tests/test_legacy_preview_bridge.py` при необходимости.

## Ideas
- Добавлена идея `2024-06-12-preview-bridge-stats` в docs/IDEAS.md.


------
https://chatgpt.com/codex/tasks/task_b_68d047c3478c8324b72e1ad222813f8f