### PR TITLE
fix: исправлена категоризация CLIP подсказок

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Arena AutoCache web overlay (experimental) has been removed from the package by default to prioritize stability across ComfyUI Desktop builds. The feature is tracked for a future iteration in the roadmap.
 ### Fixed
+- Ensure AutoCache workflow parsing assigns CLIP Vision, IPAdapter, InsightFace, CLIP-G, and CLIP-L hints to their dedicated ComfyUI categories before falling back to the generic CLIP bucket.
 - Overlay now also listens to execution events (`onAfterExecute`/`onExecuted`) in addition to `onNodeOutputsUpdated` to support ComfyUI Desktop builds that don't emit the outputs-updated callback consistently.
 - Overlay polling fallback: periodically reads node outputs (~500 ms) for Dashboard/Ops/Audit nodes to keep the UI in sync even when no frontend events are fired (Desktop compatibility).
 - Desktop execution store fallback: when `getOutputData()` returns nothing, the overlay now attempts to read outputs from the Desktop `executionStore` (supports Map/object containers and locator ids like `subgraph:localId`).

--- a/custom_nodes/ComfyUI_Arena/autocache/arena_auto_cache.py
+++ b/custom_nodes/ComfyUI_Arena/autocache/arena_auto_cache.py
@@ -332,8 +332,25 @@ def _guess_category_from_hints(
         hints.append(class_hint)
     if key_hint:
         hints.append(key_hint)
+    processed: list[tuple[str, str]] = []
     for hint in hints:
         lowered = hint.lower()
+        normalized = lowered.replace("-", "_").replace(" ", "_")
+        processed.append((lowered, normalized))
+
+    for lowered, normalized in processed:
+        if "clip_vision" in normalized or "clipvision" in normalized:
+            return "clip_vision"
+        if "ipadapter" in normalized or "ip_adapter" in normalized:
+            return "ipadapter"
+        if "insightface" in normalized or "insight_face" in normalized:
+            return "insightface"
+        if "clip_g" in normalized:
+            return "clip_g"
+        if "clip_l" in normalized:
+            return "clip_l"
+
+    for lowered, _normalized in processed:
         if "lora" in lowered or "lyco" in lowered or "lycoris" in lowered:
             return "loras"
         if "hyper" in lowered:

--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -49,3 +49,4 @@
 | 2024-06-15-autocache-allowlist-cli | Provide a CLI helper that lists the current workflow allowlist for headless warmup scripts | Tooling | 0.2 | proposed |
 | 2024-06-16-copy-worker-metrics | Track background copy queue depth and durations inside StatsEx to surface slow sources | AutoCache | 0.3 | proposed |
 | 2024-06-18-promptserver-indicator | Surface a small indicator in Audit/Warmup/Ops nodes when the PromptServer workflow fallback is active | AutoCache | 0.2 | proposed |
+| 2024-06-19-autocache-category-guide | Publish a concise reference chart mapping workflow hints to AutoCache categories so operators can troubleshoot mismatches | Docs | 0.3 | proposed |

--- a/tests/test_autocache_warmup.py
+++ b/tests/test_autocache_warmup.py
@@ -52,6 +52,48 @@ class ArenaAutoCacheParseItemsSpecTest(unittest.TestCase):
             ],
         )
 
+    def test_parse_items_spec_detects_specialized_clip_categories(self) -> None:
+        module = importlib.import_module(MODULE_NAME)
+        workflow = json.dumps(
+            {
+                "nodes": [
+                    {
+                        "class_type": "CLIPVisionLoader",
+                        "widgets_values": ["clip_vision_model.safetensors"],
+                        "inputs": {"clip_name": "clip_vision_model.safetensors"},
+                    },
+                    {
+                        "class_type": "IPAdapterModelLoader",
+                        "inputs": {"ipadapter": "ipadapter_model.safetensors"},
+                    },
+                    {
+                        "class_type": "InsightFaceLoader",
+                        "inputs": {"insightface": "insightface_detector.onnx"},
+                    },
+                    {
+                        "class_type": "CLIPTextEncode",
+                        "inputs": {
+                            "clip_g": "clip_g_text_encoder.pth",
+                            "clip_l": "clip_l_text_encoder.pth",
+                        },
+                    },
+                ]
+            }
+        )
+
+        parsed = module.parse_items_spec("", workflow, "checkpoints")
+
+        self.assertEqual(
+            {(entry["category"], entry["name"]) for entry in parsed},
+            {
+                ("clip_vision", "clip_vision_model.safetensors"),
+                ("ipadapter", "ipadapter_model.safetensors"),
+                ("insightface", "insightface_detector.onnx"),
+                ("clip_g", "clip_g_text_encoder.pth"),
+                ("clip_l", "clip_l_text_encoder.pth"),
+            },
+        )
+
 
 class ArenaAutoCacheWarmupAuditIntegrationTest(unittest.TestCase):
     """Integration tests for warmup/audit helpers operating on real files."""


### PR DESCRIPTION
## Summary
- скорректирована логика `_guess_category_from_hints`, чтобы приоритетно распознавать CLIP Vision, IPAdapter, InsightFace, CLIP-G и CLIP-L до общего правила CLIP
- расширены юнит-тесты парсинга workflow для проверки новых категорий на примерах строк из `widgets_values` и `inputs`

## Changes
- обновлён `arena_auto_cache.py` с приоритетными проверками подсказок и вспомогательной нормализацией
- добавлен тест `test_parse_items_spec_detects_specialized_clip_categories`
- зафиксировано исправление в changelog и добавлена новая идея по документации категорий

## Docs
- docs/IDEAS.md (ru)

## Changelog
- добавлена запись в [Unreleased] раздела Fixed

## Test Plan
1. `pytest tests/test_autocache_warmup.py`

## Risks
- минимальные: изменения затрагивают только эвристику категоризации при парсинге workflow

## Rollback
1. Откатить коммит
2. Перезапустить тесты `pytest tests/test_autocache_warmup.py`

## Ideas
- 2024-06-19-autocache-category-guide — занесена в docs/IDEAS.md


------
https://chatgpt.com/codex/tasks/task_b_68d125fa987c8324a362f99beaa363fc