### PR TITLE
feat: добавлены уведомления копирования для прогрева

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Legacy preview bridge now reuses cached identifiers for repeated node/file pairs so duplicate entries no longer accumulate.
 
 ### Added
+- Emit AutoCache copy lifecycle events (start/complete/skip/fail) to the console and PromptServer so overlays receive updates even with verbose logging disabled. / **RU:** Добавлены события копирования (start/complete/skip/fail) в консоль и PromptServer, теперь они доступны даже при отключённом `ARENA_CACHE_VERBOSE`.
 - Declare setuptools metadata with explicit package listings and bundle docs/web assets into distributions so wheels ship the Arena overlay.
 - Add a CI smoke test that runs `python -m build` on Python 3.10 and 3.11 to guard packaging regressions.
 - Add Arena AutoCache web overlay extension that parses `summary_json`/`warmup_json`/`trim_json` sockets and surfaces live node status, progress bars, and warnings inside the ComfyUI graph.
@@ -30,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduce `arena_bootstrap_cache.bat` to persist Arena AutoCache variables on Windows and prime the current session.
 - Add a WinForms bootstrap helper (`scripts/arena_bootstrap_cache.ps1`) for selecting the cache folder and limit on Windows.
 ### Changed
+- ArenaAutoCache Warmup/Ops nodes expose an optional `log_context` input that forwards node identifiers into copy events for overlay synchronisation. / **RU:** Узлы Warmup/Ops получили необязательный вход `log_context`, передающий ID узла в события копирования для синхронизации с оверлеем.
 - Offload Arena AutoCache LRU copies to a background queue so `get_full_path` returns immediately while the worker syncs files. / **RU:** Перенесено LRU-копирование Arena AutoCache в фоновую очередь, теперь `get_full_path` мгновенно отдаёт исходный путь, а воркер копирует файл параллельно.
 - Gate AutoCache LRU copies behind workflow allowlists so only registered category/name pairs trigger cache sync. / **RU:** Ограничено LRU-копирование AutoCache allowlist-списком из workflow, теперь синхронизация выполняется только для зарегистрированных пар категория/файл.
 - Mark ArenaAutoCache Dashboard/Ops/Audit as OUTPUT_NODE so they execute as graph targets by default (improves Desktop/queue behaviour and overlay updates).
@@ -50,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prefill Arena AutoCache overlay state on node creation so idle nodes render their headline and palette without waiting for outputs.
 - Reorder Arena Ops mode constant declarations ahead of the node class definition to clarify initialization ordering.
 ### Docs
+- Document the new copy notification channel and `log_context` behaviour in the RU/EN node references. / **RU:** Описан канал уведомлений и вход `log_context` в справочниках узлов (RU/EN).
 - Document the auto-discovery path and DevTools verification flow for the Arena web overlay in the README, RU/EN guides, and node reference. / **RU:** Задокументирован путь автообнаружения и проверка через DevTools для веб-оверлея Arena в README, русских/английских гайдах и справочнике узлов.
 - Document the AutoCache web overlay behaviour and coverage in the bilingual node reference.
 - Add step-by-step AutoCache web overlay enablement instructions with UI indicator summaries across the README and RU/EN docs.

--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -50,3 +50,5 @@
 | 2024-06-16-copy-worker-metrics | Track background copy queue depth and durations inside StatsEx to surface slow sources | AutoCache | 0.3 | proposed |
 | 2024-06-18-promptserver-indicator | Surface a small indicator in Audit/Warmup/Ops nodes when the PromptServer workflow fallback is active | AutoCache | 0.2 | proposed |
 | 2024-06-19-autocache-category-guide | Publish a concise reference chart mapping workflow hints to AutoCache categories so operators can troubleshoot mismatches | Docs | 0.3 | proposed |
+| 2024-06-20-copy-overlay-history | Surface a rolling timeline of `copy_started`/`copy_completed` events in the overlay for long warmup runs | UX | 0.3 | proposed |
+| 2024-06-20-copy-event-cli | Provide a CLI subscriber that streams `arena/autocache/copy_event` payloads for automation pipelines | Tooling | 0.4 | proposed |

--- a/docs/en/nodes.md
+++ b/docs/en/nodes.md
@@ -19,3 +19,10 @@ Covered groups:
 
 Audit/Warmup/Ops nodes refresh a workflow allowlist from the `items` and `workflow_json` inputs before they run. When `workflow_json` is empty the nodes try to read the active graph via `server.PromptServer` and continue with the current workflow. Only the enumerated category/name pairs trigger LRU copies; direct `folder_paths.get_full_path` calls without registration return source paths without priming the cache.
 
+## Copy notifications
+
+- `_copy_into_cache_lru` now emits `copy_started`, `copy_completed`, and `copy_skipped` events to the console (`[ArenaAutoCache] ...`) and mirrors them via `PromptServer.instance.send_sync("arena/autocache/copy_event", ...)` when the server is available. These events fire even when `ARENA_CACHE_VERBOSE` is disabled.
+- Failures trigger a `copy_failed` event with the exception text so the overlay can flag the issue immediately.
+- ArenaAutoCache Warmup and Ops expose an optional `log_context` string input. Supply plain text or a JSON object (e.g. `{ "node_id": "N42" }`); raw strings are wrapped into `{ "text": "..." }` automatically.
+- Warmup always adds `node="ArenaAutoCacheWarmup"`, and Ops augments the context with `node="ArenaAutoCacheOps"` plus the active `mode`. The merged context is included in every copy event, letting the overlay link progress back to a concrete node execution.
+

--- a/docs/ru/nodes.md
+++ b/docs/ru/nodes.md
@@ -23,3 +23,10 @@ description: "Справка по узлам ComfyUI Arena Suite."
 
 Узлы Audit/Warmup/Ops перед запуском обновляют allowlist моделей на основе входов `items` и `workflow_json`. Если вход `workflow_json` пуст, узлы пытаются считать активный граф через `server.PromptServer` и продолжают работать с текущей схемой. Только перечисленные пары категория/файл попадают в LRU-копирование; прямые вызовы `folder_paths.get_full_path` без регистрации возвращают исходные пути без прогрева.
 
+## Уведомления о копировании
+
+- `_copy_into_cache_lru` всегда отправляет события `copy_started`, `copy_completed` и `copy_skipped` в консоль (`[ArenaAutoCache] ...`) и, при наличии `PromptServer.instance`, синхронно ретранслирует их в канал `arena/autocache/copy_event`. События фиксируются даже при `ARENA_CACHE_VERBOSE=0`.
+- В контексте ошибок отправляется событие `copy_failed` с текстом исключения, чтобы оверлей получил сигнал о проблеме.
+- Узлы ArenaAutoCache Warmup и ArenaAutoCache Ops получили необязательный вход `log_context` (строка). Передайте текст или JSON с `node_id`, тегом пользователя и т.п. Строка автоматически оборачивается в `{"text": "..."}`.
+- Warmup автоматически добавляет в контекст поле `node="ArenaAutoCacheWarmup"`, а Ops — `node="ArenaAutoCacheOps"` и `mode=<текущий режим>`. Итоговый контекст попадает во все события копирования, что позволяет ComfyUI overlay сопоставить прогрев с конкретным узлом и его выполнением.
+

--- a/tests/test_autocache_warmup.py
+++ b/tests/test_autocache_warmup.py
@@ -8,6 +8,7 @@ import tempfile
 import types
 import unittest
 from pathlib import Path
+from typing import Mapping
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
@@ -385,7 +386,13 @@ class ArenaAutoCacheWorkflowAllowlistTest(unittest.TestCase):
             calls: list[tuple[Path, Path, str]] = []
             original_copy = module._copy_into_cache_lru
 
-            def _fake_copy(src: Path, dst: Path, category: str) -> None:
+            def _fake_copy(
+                src: Path,
+                dst: Path,
+                category: str,
+                *,
+                context: Mapping[str, object] | None = None,
+            ) -> None:
                 calls.append((Path(src), Path(dst), category))
                 dst.parent.mkdir(parents=True, exist_ok=True)
                 dst.write_text("cached", encoding="utf-8")


### PR DESCRIPTION
## Summary
- Добавил постоянный канал событий копирования (start/complete/skip/fail) с контекстом и мостом в PromptServer.
- Расширил узлы Warmup/Ops входом `log_context`, чтобы прокидывать ID узла в логи и оверлей.
- Покрыл изменения тестом на вызов логгера и обновил документацию.

## Changes
- Реализован `_notify_copy_event` и интеграция в `_copy_into_cache_lru`, очередь и warmup-проход.
- Добавлен парсер `_parse_log_context`, передача контекста в Warmup/Ops и очередь копирования.
- Добавлен юнит-тест `ArenaAutoCacheCopyNotificationTest` и адаптированы существующие заглушки.
- Обновлены RU/EN справочники узлов, CHANGELOG и список идей.

## Docs
- docs/ru/nodes.md
- docs/en/nodes.md

## Changelog
- [Unreleased] — Added/Changed/Docs записи про уведомления и `log_context`.

## Test Plan
- `pytest`

## Risks
- Дополнительные события копирования могут увеличить объём логов и требовать фильтрации на стороне интеграций.

## Rollback
- Выполнить `git revert <commit>` и перезапустить ComfyUI для отката изменений.

## Ideas
- Заведены идеи `2024-06-20-copy-overlay-history` и `2024-06-20-copy-event-cli` в docs/IDEAS.md.


------
https://chatgpt.com/codex/tasks/task_b_68d12a1a1790832484011f850799dea4