### PR TITLE
feat(autocache): Analyze/GetActiveWorkflow, fallback по last_path; группы нод

### DIFF
--- a/docs/ru/nodes.md
+++ b/docs/ru/nodes.md
@@ -9,13 +9,21 @@ description: "Справка по узлам ComfyUI Arena Suite."
 
 # Узлы Arena AutoCache
 
-- ArenaAutoCacheConfig — настройка кэша в рантайме.
-- ArenaAutoCacheStats — базовая статистика по кэшу.
-- ArenaAutoCacheStatsEx — расширенная статистика.
-- ArenaAutoCacheTrim — очистка кэша по категории.
-- ArenaAutoCacheManager — операции с категориями и путями.
-- ArenaAutoCache Audit — аудит наличия моделей.
-- ArenaAutoCache Warmup — прогрев кэша по спискам/JSON.
+Разделение по группам в ComfyUI:
+
+## Basic
+- ArenaAutoCache Analyze — автоанализ текущего воркфлоу, план копирования и автопрогрев без ввода.
+- ArenaAutoCache Ops — сводный узел: аудит + прогрев (+trim при выборе режима).
+
+## Advanced
+- ArenaAutoCache Dashboard — сводка и действия (настройки, аудит, trim) в одном месте.
+- ArenaAutoCache Manager — быстрые изменения настроек и (опц.) trim.
+- ArenaAutoCache Trim — принудительная очистка категории по LRU.
+- ArenaAutoCache StatsEx — расширенная статистика с отдельными выходами.
+
+## Utils
+- ArenaGetActiveWorkflow — возвращает текущий активный воркфлоу (JSON) из PromptServer.
+- ArenaAutoCache Stats — базовая статистика по кэшу (JSON).
 
 Примечание: точный состав узлов и выводы зависят от текущей версии. Подсказки по входам/выходам смотрите в интерфейсе ComfyUI или по всплывающим подсказкам.
 


### PR DESCRIPTION
Описание:
Новые узлы:
ArenaAutoCacheAnalyze: автоанализ активного воркфлоу, план копирования, автопрогрев без ввода. Выходы: Summary JSON, Warmup JSON.
ArenaGetActiveWorkflow: утилита для явной передачи текущего воркфлоу в узлы.
Поведение:
Если воркфлоу не распознан, fallback: берем последнюю использованную модель из индекса категории (stats.payload.last_path) и подхватываем её для прогрева.
Структура категорий:
Basic: Analyze, Ops
Advanced: Dashboard, Manager, Trim, StatsEx
Utils: GetActiveWorkflow, Stats
UX:
“Без ввода”: пустые поля → используется активный воркфлоу; Analyze/ Ops возвращают читаемый ui-блок для Show Any.
План копирования в Analyze с оценкой размеров (small-first), автозапуск warmup.
Документация:
Обновлён docs/ru/nodes.md: группы нод, минимальный сценарий.
Тесты:
Базовые автокэш-тесты проходят локально; функциональные изменения изолированы.
Checklist:
[x] Соответствует AGENTS.md (описание, конфигурация, отсутствие сетевых сайд-эффектов в узлах)
[x] Типы/выходы документированы, значения по умолчанию установлены
[x] Нет регрессий в тестах автокэша
[x] Документация обновлена