### PR TITLE
feat: simplify Arena AutoCache to OnDemand only

### DIFF
--- a/user-workflow.mdc
+++ b/user-workflow.mdc
@@ -1,0 +1,60 @@
+# User Workflow Rules
+
+## Общение
+- Все задачи формулировать простыми словами на русском языке
+- Код и комментарии в коде писать на английском
+- Документация вести на русском (основная) и при необходимости на английском
+
+## Рабочий процесс
+- Одна задача = один чат = один Issue в GitHub
+- После постановки задачи она сразу копируется в Issue
+- Вся работа ведется через Issue: все шаги, комментарии, логи и прогресс фиксируются в комментариях Issue
+- Новая цель → новый чат и новый Issue
+- Коммиты должны быть маленькими и атомарными
+- Работа до финала ведется в Issue → PR → мердж → закрытие Issue
+
+## Pull Requests
+- Все изменения проходят через Pull Request
+- PR должен быть привязан к соответствующему Issue (Closes #номер)
+- В PR обязательно указывать: Summary, Changes, Docs, Changelog, Test Plan
+- Без зелёного CI PR не мержится
+
+## Документация
+- Все изменения фиксировать в CHANGELOG.md (формат Keep a Changelog + SemVer)
+- ROADMAP.md — стратегические задачи
+- docs/ru/ — основная документация на русском
+- docs/examples/ — примеры
+- docs/migration.md — при breaking changes
+- Документация обновляется вместе с кодом в том же PR
+
+## Логи и отладка
+- При решении проблем в Issue всегда прикладывать фрагмент лога ошибки
+- В комментариях фиксировать: текст ошибки, дату/шаг возникновения, результат после исправления
+
+## Code Quality
+- Проверять синтаксис после изменений
+- Комментировать сложные изменения
+- Все результаты экспериментов отражать в связанных Issues
+
+## Context7 Documentation
+- Использовать Context7 для получения актуальной документации по библиотекам
+- При работе с новыми библиотеками сначала искать через Context7
+- Документация обновляется автоматически и содержит актуальные примеры кода
+
+## GitHub MCP
+- Использовать GitHub MCP для работы с Issues и Pull Requests
+- Создавать Issues через MCP для автоматизации процесса
+- Отслеживать прогресс работы через GitHub API
+- Управлять PR и комментариями через MCP
+
+## ComfyUI Desktop Paths
+### Основные пути
+- **ComfyUI Desktop**: `c:\Users\acherednikov\AppData\Local\Programs\@comfyorgcomfyui-electron\`
+- **Пользовательская папка**: `c:\ComfyUI\` (модели, ноды и т.д.)
+- **Python Virtual Environment**: `c:\ComfyUI\.venv\`
+- **Логи**: `c:\Users\acherednikov\AppData\Roaming\ComfyUI\logs\`
+- **Extra Model Paths**: `c:\Users\acherednikov\AppData\Local\Programs\@comfyorgcomfyui-electron\resources\ComfyUI\extra_model_paths.yaml`
+
+### Web Extensions
+- **Основной путь**: `c:\Users\acherednikov\AppData\Local\Programs\@comfyorgcomfyui-electron\resources\ComfyUI\web\extensions\`
+- **Альтернативный путь**: `c:\Users\acherednikov\AppData\Local\Programs\@comfyorgcomfyui-electron\resources\ComfyUI\web_custom_versions\desktop_app\extensions\`


### PR DESCRIPTION
## 🎯 **Упрощение Arena AutoCache до OnDemand режима**

### 📋 **Что сделано**
- ✅ Убран параметр `force_warmup` (не нужен в OnDemand режиме)
- ✅ Упрощен интерфейс до 2 параметров: `categories` и `min_size_mb`
- ✅ Убраны неиспользуемые переменные сессии
- ✅ Очищена сложная логика Preload режима
- ✅ Обновлена документация

### 🔧 **Финальный интерфейс**
- **categories**: "checkpoints,loras,vaes,upscale_models,controlnet"
- **min_size_mb**: 10.0 (настраивается через ARENA_CACHE_MIN_SIZE_MB)

### 🚀 **Преимущества**
- Простая и надежная система OnDemand кеширования
- Прозрачное кеширование при первом обращении
- Неблокирующее фоновое копирование
- Минимальный интерфейс

### 📚 **Обновления документации**
- Обновлен CHANGELOG.md с упрощенным описанием
- Обновлена docs/ru/cache_warmup.md для OnDemand режима
- Убраны ссылки на Preload и сложные функции

**Closes #91**